### PR TITLE
fix_select_master_db

### DIFF
--- a/src/aws/repository.go
+++ b/src/aws/repository.go
@@ -110,7 +110,7 @@ const selectGetAWSByAccountID = `select * from aws where project_id = ? and aws_
 
 func (a *awsRepository) GetAWSByAccountID(projectID uint32, awsAccountID string) (*model.AWS, error) {
 	data := model.AWS{}
-	if err := a.SlaveDB.Raw(selectGetAWSByAccountID, projectID, awsAccountID).First(&data).Error; err != nil {
+	if err := a.MasterDB.Raw(selectGetAWSByAccountID, projectID, awsAccountID).First(&data).Error; err != nil {
 		return nil, err
 	}
 	return &data, nil
@@ -236,7 +236,7 @@ const selectGetAWSRelDataSourceByID = `select * from aws_rel_data_source where a
 
 func (a *awsRepository) GetAWSRelDataSourceByID(awsID, awsDataSourceID, projectID uint32) (*model.AWSRelDataSource, error) {
 	data := model.AWSRelDataSource{}
-	if err := a.SlaveDB.Raw(selectGetAWSRelDataSourceByID, awsID, awsDataSourceID, projectID).First(&data).Error; err != nil {
+	if err := a.MasterDB.Raw(selectGetAWSRelDataSourceByID, awsID, awsDataSourceID, projectID).First(&data).Error; err != nil {
 		return nil, err
 	}
 	return &data, nil


### PR DESCRIPTION
RDBがMaster-Slave構成の場合、Mutation系のAPIでデータ登録後にすぐにselectしている箇所はSlaveではなくMasterのDB参照するように変更します。
レプリの遅延（0.2秒程度）の影響でAPIがエラーを返すケースが発生していたため