### PR TITLE
fix all region process

### DIFF
--- a/src/access-analyzer/handler.go
+++ b/src/access-analyzer/handler.go
@@ -113,9 +113,9 @@ func (s *sqsHandler) getAccessAnalyzer(msg *message.AWSQueueMessage) ([]*finding
 		appLogger.Infof("Detected analyzer: analyzerArn=%s, accountID=%s", arn, msg.AccountID)
 		findings, err := s.accessAnalyzer.listFindings(msg.AccountID, arn)
 		if err != nil {
-			appLogger.Errorf(
+			appLogger.Warnf(
 				"AccessAnalyzer.ListFindings error: analyzerArn=%s, accountID=%s, err=%+v", arn, msg.AccountID, err)
-			return nil, err
+			continue // If Organization gathering enabled, requesting an invalid Region may result in an error.
 		}
 		appLogger.Debugf("[Debug]Got findings, %+v", findings)
 		if len(findings) == 0 {

--- a/src/guard-duty/handler.go
+++ b/src/guard-duty/handler.go
@@ -110,11 +110,10 @@ func (s *sqsHandler) getGuardDuty(message *message.AWSQueueMessage) ([]*finding.
 		fmt.Printf("detecterId: %s\n", id)
 		findingIDs, err := s.guardduty.listFindings(message.AccountID, id)
 		if err != nil {
-			appLogger.Errorf(
+			appLogger.Warnf(
 				"GuardDuty.ListDetectors error: detectorID=%s, accountID=%s, err=%+v", id, message.AccountID, err)
-			return nil, err
+			continue // If Organization gathering enabled, requesting an invalid Region may result in an error.
 		}
-
 		if len(findingIDs) == 0 {
 			appLogger.Infof("No findings: accountID=%s", message.AccountID)
 			continue


### PR DESCRIPTION
全リージョン対応した際に考慮漏れがありました。
Organizationで管理してる場合に、代理管理者側で有効になっているリージョンでも、監視対象のアカウントで有効になっていない場合にエラーで取得できないケースがありました。

エラー時のハンドリングを修正します。（エラー終了せずにログだけ吐いて他のリージョンの処理を回し切る形にします）