### PR TITLE
fix for regional service

### DIFF
--- a/src/access-analyzer/accessanalyzer.go
+++ b/src/access-analyzer/accessanalyzer.go
@@ -64,8 +64,8 @@ func (a *accessAnalyzerClient) newAWSSession(region, assumeRole, externalID stri
 		})
 	}
 	a.Sess = sess
-	a.Svc = accessanalyzer.New(a.Sess)
-	a.EC2 = ec2.New(a.Sess)
+	a.Svc = accessanalyzer.New(a.Sess, aws.NewConfig().WithRegion(region))
+	a.EC2 = ec2.New(a.Sess, aws.NewConfig().WithRegion(region))
 	return nil
 }
 

--- a/src/guard-duty/guardduty.go
+++ b/src/guard-duty/guardduty.go
@@ -66,8 +66,8 @@ func (g *guardDutyClient) newAWSSession(region, assumeRole, externalID string) e
 		})
 	}
 	g.Sess = sess
-	g.Svc = guardduty.New(g.Sess)
-	g.EC2 = ec2.New(g.Sess)
+	g.Svc = guardduty.New(g.Sess, aws.NewConfig().WithRegion(region))
+	g.EC2 = ec2.New(g.Sess, aws.NewConfig().WithRegion(region))
 	return nil
 }
 


### PR DESCRIPTION
GuardDutyとAWS AccessAnalyzerのスキャン対象になっているもののうち、Regionalサービスはうまく取得できてなかったので修正。