### PR TITLE
fix cloudsploit session duration

### DIFF
--- a/src/cloudsploit/config.go
+++ b/src/cloudsploit/config.go
@@ -28,10 +28,15 @@ func (c *cloudsploitConfig) makeConfig(region, assumeRole, externalID string) (s
 		creds = stscreds.NewCredentials(
 			sess, assumeRole, func(p *stscreds.AssumeRoleProvider) {
 				p.ExternalID = aws.String(externalID)
+				p.Duration = time.Duration(60) * time.Minute
 			},
 		)
 	} else {
-		creds = stscreds.NewCredentials(sess, assumeRole)
+		creds = stscreds.NewCredentials(
+			sess, assumeRole, func(p *stscreds.AssumeRoleProvider) {
+				p.Duration = time.Duration(60) * time.Minute
+			},
+		)
 	}
 	val, err := creds.Get()
 	if err != nil {


### PR DESCRIPTION
一部のプロジェクトについて、APIリクエスト数がかなり多く、デフォルトのクレデンシャル有効時間では完了しきらなかったため、有効時間を延長しました。