### PR TITLE
fix sleep milli sec

### DIFF
--- a/src/access-analyzer/accessanalyzer.go
+++ b/src/access-analyzer/accessanalyzer.go
@@ -132,7 +132,7 @@ func (a *accessAnalyzerClient) listFindings(accountID string, analyzerArn string
 			break
 		}
 		nextToken = *out.NextToken
-		time.Sleep(time.Millisecond * 100)
+		time.Sleep(time.Millisecond * 500)
 	}
 	return findings, nil
 }

--- a/src/guard-duty/guardduty.go
+++ b/src/guard-duty/guardduty.go
@@ -165,7 +165,7 @@ func (g *guardDutyClient) getFindings(detectorID string, findingIDs []*string) (
 		for _, f := range finding.Findings {
 			guardDutyFindings = append(guardDutyFindings, f)
 		}
-		time.Sleep(time.Millisecond * 100)
+		time.Sleep(time.Millisecond * 500)
 	}
 	return guardDutyFindings, nil
 }


### PR DESCRIPTION
#65 が改善していないため、リクエストの流量を調整します。

TooManyRequestsの原因は以下のように記載があるため、少しずつ調整しています

> The client is sending more than the allowed number of requests per unit of time.

https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/index.html?com/amazonaws/services/serverlessapplicationrepository/model/TooManyRequestsException.html


