### PR TITLE
update env-injector

### DIFF
--- a/src/portscan/Dockerfile
+++ b/src/portscan/Dockerfile
@@ -11,8 +11,8 @@ RUN go install -v
 
 FROM alpine
 RUN apk add --no-cache ca-certificates tzdata nmap nmap-scripts \
-  && cd /tmp/ && wget -q https://github.com/okzk/env-injector/releases/download/v0.0.5/env-injector_0.0.5_linux_amd64.tar.gz \
-  && tar xvfz env-injector_0.0.5_linux_amd64.tar.gz && mv env-injector /usr/local/bin/ && rm /tmp/*
+  && cd /tmp/ && wget -q https://github.com/gassara-kys/env-injector/releases/download/v0.0.6/env-injector_0.0.6_Linux_x86_64.tar.gz \
+  && tar xvfz env-injector_0.0.6_Linux_x86_64.tar.gz && mv env-injector /usr/local/bin/ && rm -rf /tmp/*
 COPY --from=builder /go/bin/portscan /usr/local/portscan/bin/
 ENV DEBUG= \
     AWS_REGION= \


### PR DESCRIPTION
env-injectorのバージョンをあげます。
既存のバージョンではaws SDKのバージョンが古く、Fargate対応後にうまく認証情報取得できないため