### PR TITLE
add access report

### DIFF
--- a/src/admin-checker/handler_test.go
+++ b/src/admin-checker/handler_test.go
@@ -56,3 +56,48 @@ func TestScoreAdminUser(t *testing.T) {
 		})
 	}
 }
+
+func TestScoreAccessReport(t *testing.T) {
+	cases := []struct {
+		name  string
+		input *serviceAccessedReport
+		want  float32
+	}{
+		{
+			name: "Too many policies",
+			input: &serviceAccessedReport{
+				AccessRate: 0.3,
+			},
+			want: 0.7,
+		},
+		{
+			name: "Many policies",
+			input: &serviceAccessedReport{
+				AccessRate: 0.5,
+			},
+			want: 0.5,
+		},
+		{
+			name: "Many policies",
+			input: &serviceAccessedReport{
+				AccessRate: 0.7,
+			},
+			want: 0.3,
+		},
+		{
+			name: "Many policies",
+			input: &serviceAccessedReport{
+				AccessRate: 1.0,
+			},
+			want: 0.1,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := scoreAccessReport(c.input)
+			if c.want != got {
+				t.Fatalf("Unexpected resource name: want=%v, got=%v", c.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
AdminCheckerに[アクセスアドバイザー](https://docs.aws.amazon.com/ja_jp/IAM/latest/UserGuide/access_policies_access-advisor-view-data.html)をベースにしたスキャン機能を実装します。

これはざっくり以下の仕様です。

- IAMユーザのAdmin判定のFindingとは別データとして登録する
- IAMユーザとIAMロールに対して以下の解析を行う
  - 許可されたサービスに対して実際にアクセスしたサービスの割合を計算する
  - 最小権限のプラクティスにのっとり、過剰に許可されてると判断した場合にスコアが高く設定