### PR TITLE
fix: controll API call rating

### DIFF
--- a/src/admin-checker/admin_checker.go
+++ b/src/admin-checker/admin_checker.go
@@ -146,6 +146,7 @@ func (a *adminCheckerClient) listUser(ctx context.Context) (*[]iamUser, error) {
 				JobID: jobID,
 			},
 		})
+		time.Sleep(time.Millisecond * 1000) // For control the API call rating.
 	}
 	for idx, user := range iamUsers {
 		jobID := user.ServiceAccessedReport.JobID
@@ -155,6 +156,7 @@ func (a *adminCheckerClient) listUser(ctx context.Context) (*[]iamUser, error) {
 			continue
 		}
 		iamUsers[idx].ServiceAccessedReport = *accessedDetail
+		time.Sleep(time.Millisecond * 1000) // For control the API call rating.
 	}
 	return &iamUsers, nil
 }
@@ -485,6 +487,7 @@ func (a *adminCheckerClient) listRole(ctx context.Context) (*[]iamRole, error) {
 				JobID: jobID,
 			},
 		})
+		time.Sleep(time.Millisecond * 1000) // For control the API call rating.
 	}
 	for idx, role := range iamRoles {
 		jobID := role.ServiceAccessedReport.JobID
@@ -494,6 +497,7 @@ func (a *adminCheckerClient) listRole(ctx context.Context) (*[]iamRole, error) {
 			continue
 		}
 		iamRoles[idx].ServiceAccessedReport = *accessedDetail
+		time.Sleep(time.Millisecond * 1000) // For control the API call rating.
 	}
 	return &iamRoles, nil
 }


### PR DESCRIPTION
以下のエラーが発生していたため、APIコール数を調整します。

```
Throttling: Rate exceeded\n\tstatus code: 400, 
```

[Route53のドキュメント](https://aws.amazon.com/jp/premiumsupport/knowledge-center/route-53-avoid-throttling-errors/)ですが、1秒あたりに5回というのが目安としてありそう。（IAM関連のドキュメントは見当たりませんでした。）

> Throttling の値を持つ Code 要素と Rate exceeded の値を持つ Message 要素を含むレスポンスヘッダーは、レートのスロットリングを示します。レートスロットリングは、API リクエストの数が、(アカウントごとに) 1 秒あたり 5 つのリクエストというハード制限よりも多い場合に発生します。




