### PR TITLE
fix aws portscan

### DIFF
--- a/src/portscan/go.mod
+++ b/src/portscan/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/ca-risken/aws/pkg/message v0.0.0-20211004102725-c7fcf33f3fd3
 	github.com/ca-risken/aws/proto/aws v0.0.0-20211004102725-c7fcf33f3fd3
 	github.com/ca-risken/common/pkg/logging v0.0.0-20211118071101-9855266b50a1
-	github.com/ca-risken/common/pkg/portscan v0.0.0-20211118071101-9855266b50a1
+	github.com/ca-risken/common/pkg/portscan v0.0.0-20211124090848-375c75e97506
 	github.com/ca-risken/common/pkg/sqs v0.0.0-20211118071101-9855266b50a1
 	github.com/ca-risken/common/pkg/xray v0.0.0-20211118071101-9855266b50a1
 	github.com/ca-risken/core/proto/alert v0.0.0-20211004070125-d4ec17a60d36

--- a/src/portscan/go.sum
+++ b/src/portscan/go.sum
@@ -43,6 +43,8 @@ github.com/ca-risken/common/pkg/logging v0.0.0-20211118071101-9855266b50a1 h1:uG
 github.com/ca-risken/common/pkg/logging v0.0.0-20211118071101-9855266b50a1/go.mod h1:h0Rj4W2YM6pAPyTT60bVdfpCDALOV8SMpZZCx8GhkYI=
 github.com/ca-risken/common/pkg/portscan v0.0.0-20211118071101-9855266b50a1 h1:Z7xy+bCkdb4HKXRdtb9YDkkUJ3ZJTNdOAL0E9pKPR3k=
 github.com/ca-risken/common/pkg/portscan v0.0.0-20211118071101-9855266b50a1/go.mod h1:4JgzkE62Dv8uTvhAqTRE8KQWIZ6oQX2CcgfS6nf/I4Q=
+github.com/ca-risken/common/pkg/portscan v0.0.0-20211124090848-375c75e97506 h1:CzHkYFdS+12VuR+4h1hOshuHUGiOtldKIwXq9XrDV84=
+github.com/ca-risken/common/pkg/portscan v0.0.0-20211124090848-375c75e97506/go.mod h1:4JgzkE62Dv8uTvhAqTRE8KQWIZ6oQX2CcgfS6nf/I4Q=
 github.com/ca-risken/common/pkg/sqs v0.0.0-20210924080827-df6e4ac73f01/go.mod h1:IxYbziqfohwo7y7Zn15W2emT4ubB5duUzdvj5fYhHJ4=
 github.com/ca-risken/common/pkg/sqs v0.0.0-20211118071101-9855266b50a1 h1:mHASUUV7qA2Z9wa6JQQ34W10txcoYo98X5zz0B0Lozo=
 github.com/ca-risken/common/pkg/sqs v0.0.0-20211118071101-9855266b50a1/go.mod h1:PnGxivikVgnsel3YoM1W8a6ZlrlXL7pXb7UdKDFW96Q=

--- a/src/portscan/portscan.go
+++ b/src/portscan/portscan.go
@@ -123,32 +123,26 @@ func (p *portscanClient) getResult(ctx context.Context, message *message.AWSQueu
 	err := p.listSecurityGroup(ctx)
 	if err != nil {
 		appLogger.Errorf("Faild to describeSecurityGroups: err=%+v", err)
-		return putData, err
 	}
 	err = p.listEC2(ctx, message.AccountID)
 	if err != nil {
 		appLogger.Errorf("Faild to describeInstances: err=%+v", err)
-		return putData, err
 	}
 	err = p.listELB(ctx, message.AccountID)
 	if err != nil {
 		appLogger.Errorf("Faild to describeLoadBalancers: err=%+v", err)
-		return putData, err
 	}
 	err = p.listELBv2(ctx)
 	if err != nil {
 		appLogger.Errorf("Faild to describeLoadBalancers(elbv2): err=%+v", err)
-		return putData, err
 	}
 	err = p.listRDS(ctx)
 	if err != nil {
 		appLogger.Errorf("Faild to describeDBInstances(rds): err=%+v", err)
-		return putData, err
 	}
 	err = p.listLightsail(ctx)
 	if err != nil {
-		appLogger.Errorf("Faild to getInstances(lightsail): err=%+v", err)
-		return putData, err
+		appLogger.Warnf("Faild to getInstances(lightsail): err=%+v", err)
 	}
 	excludeList := p.excludeScan()
 	nmapResults, err := p.scan()


### PR DESCRIPTION
https://github.com/ca-risken/internal-community/issues/106
への対応のため、対象取得のAPIに失敗した場合もRegionをスキップしないように修正しました。
commonのportscanを更新しました。(udpの詳細チェックスキップ)