### PR TITLE
add: detail log

### DIFF
--- a/src/cloudsploit/cloudsploit.go
+++ b/src/cloudsploit/cloudsploit.go
@@ -47,9 +47,7 @@ func (c *cloudsploitConfig) run(accountID string) (*[]cloudSploitResult, error) 
 	err := cmd.Run()
 
 	if err != nil {
-		appLogger.Errorf("Failed to execute theHarvester. stderr: %v", stderr.String())
-		appLogger.Errorf("Failed exec cloudsploit. error: %v", err)
-		return nil, fmt.Errorf("Failed exec cloudsploit. error: %v", err)
+		return nil, fmt.Errorf("Failed exec cloudsploit. error: %+v, detail: %s", err, stderr.String())
 	}
 
 	bytes, err := readFile(filePath)

--- a/src/cloudsploit/handler.go
+++ b/src/cloudsploit/handler.go
@@ -66,7 +66,7 @@ func (s *sqsHandler) HandleMessage(ctx context.Context, sqsMsg *sqs.Message) err
 	cloudsploitResult, err := cloudsploitConfig.run(msg.AccountID)
 	segment.Close(err)
 	if err != nil {
-		appLogger.Errorf("Failed exec cloudsploit, error: %v", err)
+		appLogger.Errorf("Failed to exec cloudsploit, error: %v", err)
 		return s.handleErrorWithUpdateStatus(ctx, &status, err)
 	}
 


### PR DESCRIPTION
CloudSploitコマンド実行エラー時の詳細・ヒントを追記し、ステータス画面で確認できるようにします
```
Failed exec cloudsploit. error: exit status 1
```