### PR TITLE
fix: porscan error

### DIFF
--- a/src/portscan/portscan_test.go
+++ b/src/portscan/portscan_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elbv2"
+)
+
+func TestSetELBv2(t *testing.T) {
+	cases := []struct {
+		name  string
+		input *elbv2.DescribeLoadBalancersOutput
+		want  []*target
+	}{
+		{
+			name: "OK",
+			input: &elbv2.DescribeLoadBalancersOutput{
+				LoadBalancers: []*elbv2.LoadBalancer{
+					{
+						LoadBalancerArn: aws.String("arn"),
+						DNSName:         aws.String("dns"),
+						SecurityGroups:  []*string{aws.String("sg-1"), aws.String("sg-2")},
+					},
+				},
+			},
+			want: []*target{
+				{
+					Arn:           "arn",
+					Target:        "dns",
+					FromPort:      80,
+					ToPort:        80,
+					Protocol:      "http",
+					SecurityGroup: "sg-1",
+					Category:      "elbv2",
+				},
+			},
+		},
+		{
+			name:  "Nil",
+			input: nil,
+			want:  nil,
+		},
+		{
+			name: "No Arn & DNS",
+			input: &elbv2.DescribeLoadBalancersOutput{
+				LoadBalancers: []*elbv2.LoadBalancer{
+					{
+						LoadBalancerArn: nil,
+						DNSName:         nil,
+						SecurityGroups:  []*string{aws.String("sg-1"), aws.String("sg-2")},
+					},
+				},
+			},
+			want: []*target{
+				{
+					Arn:           "",
+					Target:        "",
+					FromPort:      80,
+					ToPort:        80,
+					Protocol:      "http",
+					SecurityGroup: "sg-1",
+					Category:      "elbv2",
+				},
+			},
+		},
+		{
+			name: "No DNSName",
+			input: &elbv2.DescribeLoadBalancersOutput{
+				LoadBalancers: []*elbv2.LoadBalancer{
+					{
+						LoadBalancerArn: aws.String("arn"),
+						DNSName:         nil,
+						SecurityGroups:  []*string{aws.String("sg-1"), aws.String("sg-2")},
+					},
+				},
+			},
+			want: []*target{
+				{
+					Arn:           "arn",
+					Target:        "",
+					FromPort:      80,
+					ToPort:        80,
+					Protocol:      "http",
+					SecurityGroup: "sg-1",
+					Category:      "elbv2",
+				},
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// init
+			p := portscanClient{
+				SecurityGroups: []*targetSG{
+					{
+						fromPort:  80,
+						toPort:    80,
+						protocol:  "http",
+						groupID:   "sg-1",
+						groupName: "gName",
+					},
+				},
+			}
+			p.setELBv2(c.input)
+			for i, target := range p.target {
+				t.Logf("%d: %+v", i, target)
+			}
+			if !reflect.DeepEqual(c.want, p.target) {
+				t.Fatalf("Unexpected data: want=%+v, got=%+v", c.want, p.target)
+			}
+		})
+	}
+}
+
+func TestConvertNilString(t *testing.T) {
+	cases := []struct {
+		name  string
+		input *string
+		want  string
+	}{
+		{
+			name:  "OK",
+			input: aws.String("test"),
+			want:  "test",
+		},
+		{
+			name:  "Nil",
+			input: nil,
+			want:  "",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := convertNilString(c.input)
+			if !reflect.DeepEqual(c.want, got) {
+				t.Fatalf("Unexpected data: want=%+v, got=%+v", c.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
portscanのELBのリスト処理でPanicが起きてる件、取り急ぎ以下の対応を入れてみました
- *stringの扱いでInvalid memory accessが発生しているので、nilの場合はブランクにしました
- テストを書きたかったので、外部APIの処理とロジック部分を分けて、ロジック部分のテストを書きました。
- Invalid memory accessが発生する可能性のあるコードは他にもありましたが、現状エラーになってしまっている `listELBv2` 部分のみ対応しています