### PR TITLE
fix: session duration

### DIFF
--- a/src/cloudsploit/config.go
+++ b/src/cloudsploit/config.go
@@ -23,7 +23,7 @@ func (c *CloudsploitConfig) generate(assumeRole, externalID string, awsID uint32
 		return err
 	}
 	roleDuration, err := getRoleMaxSessionDuration(creds, c.AWSRegion, assumeRole)
-	if err == nil && roleDuration != 3600 {
+	if err == nil && roleDuration < 3600 {
 		creds, err = getCredential(assumeRole, externalID, roleDuration)
 		if err != nil {
 			return err


### PR DESCRIPTION
AssumeRoleのセッションが1時間以上設定できない仕様になっているため、RISKEN側もあわせて修正します
https://docs.aws.amazon.com/ja_jp/IAM/latest/UserGuide/id_roles_terms-and-concepts.html

> ロールの連鎖
ロールの連鎖は、AWS CLI または API を使用して 2 つ目のロールを引き受けるロールを使用する場合に発生します。
(中略)
ロールの連鎖では、AWS CLI または AWS API ロールセッションは最長 1 時間に制限されます。[AssumeRole](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html) 
(中略)
ロールの連鎖を使用してロールを引き受ける場合、DurationSeconds パラメータ値で 1 時間を超える値を指定すると、オペレーションは失敗します


関連: https://github.com/ca-risken/internal-community/issues/188
