### PR TITLE
add: memory size option

### DIFF
--- a/src/cloudsploit/Dockerfile
+++ b/src/cloudsploit/Dockerfile
@@ -31,6 +31,7 @@ ENV DEBUG= \
   RESULT_DIR=/tmp \
   CONFIG_DIR=/tmp \
   CLOUDSPLOIT_DIR="/opt/cloudsploit" \
+  MAX_MEM_SIZE_MB= \
   TZ=Asia/Tokyo
 WORKDIR /usr/local/cloudsploit
 ENTRYPOINT ["/usr/local/bin/env-injector"]

--- a/src/cloudsploit/cloudsploit.go
+++ b/src/cloudsploit/cloudsploit.go
@@ -16,10 +16,14 @@ type CloudsploitConfig struct {
 	CloudsploitDir string
 	AWSRegion      string
 	ConfigPath     string
+	MaxMemSizeMB   int
 }
 
 func (c *CloudsploitConfig) run(accountID string) (*[]cloudSploitResult, error) {
 	now := time.Now().UnixNano()
+	if c.MaxMemSizeMB > 0 {
+		os.Setenv("NODE_OPTIONS", fmt.Sprintf("--max-old-space-size=%d", c.MaxMemSizeMB))
+	}
 	filePath := fmt.Sprintf("%v/%v_%v.json", c.ResultDir, accountID, now)
 	cmd := exec.Command(fmt.Sprintf("%v/index.js", c.CloudsploitDir),
 		"--config", c.ConfigPath,

--- a/src/cloudsploit/handler.go
+++ b/src/cloudsploit/handler.go
@@ -26,6 +26,7 @@ type sqsHandler struct {
 	configDir      string
 	cloudsploitDir string
 	awsRegion      string
+	maxMemSizeMB   int
 }
 
 func (s *sqsHandler) HandleMessage(ctx context.Context, sqsMsg *sqs.Message) error {
@@ -56,6 +57,7 @@ func (s *sqsHandler) HandleMessage(ctx context.Context, sqsMsg *sqs.Message) err
 		ConfigDir:      s.configDir,
 		CloudsploitDir: s.cloudsploitDir,
 		AWSRegion:      s.awsRegion,
+		MaxMemSizeMB:   s.maxMemSizeMB,
 	}
 	err = cloudsploitConf.generate(msg.AssumeRoleArn, msg.ExternalID, msg.AWSID, msg.AccountID)
 	if err != nil {

--- a/src/cloudsploit/main.go
+++ b/src/cloudsploit/main.go
@@ -47,6 +47,7 @@ type AppConfig struct {
 	ResultDir      string `required:"true" split_words:"true" default:"/tmp"`
 	ConfigDir      string `required:"true" split_words:"true" default:"/tmp"`
 	CloudsploitDir string `required:"true" split_words:"true" default:"/opt/cloudsploit"`
+	MaxMemSizeMB   int    `split_words:"true"`
 }
 
 func main() {
@@ -85,6 +86,7 @@ func main() {
 		configDir:      conf.ConfigDir,
 		cloudsploitDir: conf.CloudsploitDir,
 		awsRegion:      conf.AWSRegion,
+		maxMemSizeMB:   conf.MaxMemSizeMB,
 	}
 	handler.findingClient = newFindingClient(conf.FindingSvcAddr)
 	handler.alertClient = newAlertClient(conf.AlertSvcAddr)


### PR DESCRIPTION
PodのメモリLimitを使い切る前にJavascriptのメモリのヒープサイズ上限に達していたので、オプションでメモリ量を指定できるようにします
 e.g.)
```shell
MAX_MEM_SIZE_MB=2048 # (2GB)
```

- [メモリオプション(公式リファレンス)](https://nodejs.org/api/cli.html#--max-old-space-sizesize-in-megabytes)
- [versionごとのheapサイズのデフォルト値](https://medium.com/geekculture/node-js-default-memory-settings-3c0fe8a9ba1)
