### PR TITLE
fix-portscan

### DIFF
--- a/src/portscan/handler.go
+++ b/src/portscan/handler.go
@@ -88,7 +88,9 @@ func (s *sqsHandler) HandleMessage(ctx context.Context, sqsMsg *sqs.Message) err
 		}
 		targets, securityGroups, err := portscan.getTargets(ctx, msg)
 		targetsAllRegion = append(targetsAllRegion, targets...)
-		securityGroupsAllRegion = mergeSecurityGroups(securityGroupsAllRegion, securityGroups)
+		for k, v := range securityGroups {
+			securityGroupsAllRegion[k] = v
+		}
 		if err != nil {
 			appLogger.Errorf("Failed to get findings to AWS Portscan: AccountID=%+v, err=%+v", msg.AccountID, err)
 			return s.handleErrorWithUpdateStatus(ctx, &status, err)
@@ -166,11 +168,4 @@ func (s *sqsHandler) analyzeAlert(ctx context.Context, projectID uint32) error {
 		ProjectId: projectID,
 	})
 	return err
-}
-
-func mergeSecurityGroups(base map[string]*relSecurityGroupArn, addition map[string]*relSecurityGroupArn) map[string]*relSecurityGroupArn {
-	for k, v := range addition {
-		base[k] = v
-	}
-	return base
 }

--- a/src/portscan/portscan_test.go
+++ b/src/portscan/portscan_test.go
@@ -158,43 +158,6 @@ func TestExcludeScan(t *testing.T) {
 	}
 }
 
-func TestMergeSecurityGroups(t *testing.T) {
-	cases := []struct {
-		name            string
-		inputBase       map[string]*relSecurityGroupArn
-		inputAdditional map[string]*relSecurityGroupArn
-		want            map[string]*relSecurityGroupArn
-	}{
-		{
-			name: "OK",
-			inputBase: map[string]*relSecurityGroupArn{
-				"hoge": {
-					ReferenceARNs: []string{"hoge1"},
-				},
-			},
-			inputAdditional: map[string]*relSecurityGroupArn{
-				"fuga": {
-					ReferenceARNs: []string{"fuga"},
-				}},
-			want: map[string]*relSecurityGroupArn{
-				"hoge": {
-					ReferenceARNs: []string{"hoge1"},
-				},
-				"fuga": {
-					ReferenceARNs: []string{"fuga"},
-				}},
-		},
-	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			got := mergeSecurityGroups(c.inputBase, c.inputAdditional)
-			if !reflect.DeepEqual(c.want, got) {
-				t.Fatalf("Unexpected data: want=%+v, got=%+v", c.want, got)
-			}
-		})
-	}
-}
-
 func TestConvertNilString(t *testing.T) {
 	cases := []struct {
 		name  string


### PR DESCRIPTION
スキャン並列化の前段として、全Regionからスキャン対象を取得した後にスキャンを実行するよう変更します