### PR TITLE
fix: use PutResrouceBatch API

### DIFF
--- a/src/cloudsploit/finding.go
+++ b/src/cloudsploit/finding.go
@@ -23,7 +23,7 @@ func (s *sqsHandler) putFindings(ctx context.Context, results *[]cloudSploitResu
 		findingBatchParam  []*finding.FindingBatchForUpsert
 		resourceBatchParam []*finding.ResourceBatchForUpsert
 	)
-
+	resourceNameMap := map[string]bool{}
 	for _, result := range *results {
 		data, err := json.Marshal(map[string]cloudSploitResult{"data": result})
 		if err != nil {
@@ -38,6 +38,10 @@ func (s *sqsHandler) putFindings(ctx context.Context, results *[]cloudSploitResu
 		score := getScore(result.Status, result.Category, result.Plugin)
 		if score == 0.0 {
 			// resource
+			if _, ok := resourceNameMap[resourceName]; ok {
+				continue // skip duplicated resource
+			}
+			resourceNameMap[resourceName] = true
 			var resourceTagForBatch []*finding.ResourceTagForBatch
 			for _, tag := range tags {
 				resourceTagForBatch = append(resourceTagForBatch, &finding.ResourceTagForBatch{Tag: tag})

--- a/src/cloudsploit/go.mod
+++ b/src/cloudsploit/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/ca-risken/common/pkg/sqs v0.0.0-20220405112424-88b993567364
 	github.com/ca-risken/common/pkg/xray v0.0.0-20211118071101-9855266b50a1
 	github.com/ca-risken/core/proto/alert v0.0.0-20211129081226-f2531e88f350
-	github.com/ca-risken/core/proto/finding v0.0.0-20220412093922-1f5c2ba990ad
+	github.com/ca-risken/core/proto/finding v0.0.0-20220420021419-f62e1a1e6a9b
 	github.com/gassara-kys/envconfig v1.4.4
 	github.com/gassara-kys/go-sqs-poller/worker/v4 v4.0.0-20210215110542-0be358599a2f
 	github.com/stretchr/testify v1.7.0

--- a/src/cloudsploit/go.sum
+++ b/src/cloudsploit/go.sum
@@ -62,6 +62,8 @@ github.com/ca-risken/core/proto/alert v0.0.0-20211129081226-f2531e88f350/go.mod 
 github.com/ca-risken/core/proto/finding v0.0.0-20220309052852-c058b4e5cb84/go.mod h1:3KZ1YanhizuVyAqMnCG7sI8Rt2mTvsWfB1GieIvoGRI=
 github.com/ca-risken/core/proto/finding v0.0.0-20220412093922-1f5c2ba990ad h1:kodGYiT/yMEJed7DjpKTjtFF+mwSixVw7sprk4/yR0I=
 github.com/ca-risken/core/proto/finding v0.0.0-20220412093922-1f5c2ba990ad/go.mod h1:3KZ1YanhizuVyAqMnCG7sI8Rt2mTvsWfB1GieIvoGRI=
+github.com/ca-risken/core/proto/finding v0.0.0-20220420021419-f62e1a1e6a9b h1:k+TDoe6H7cNmb45aybqYZZUldCD4YYBi5gZfgcAtgWM=
+github.com/ca-risken/core/proto/finding v0.0.0-20220420021419-f62e1a1e6a9b/go.mod h1:3KZ1YanhizuVyAqMnCG7sI8Rt2mTvsWfB1GieIvoGRI=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=


### PR DESCRIPTION
パフォーマンス向上の目的でResourceの登録処理をPutResrouceBatch API方式に変更します
（PutResrouceBatch呼び出しの並列化はパフォーマンスの改善状況やDBの負荷状況などの様子を見てから判断する想定です）