### PR TITLE
fix: default MaxMemSizeMB

### DIFF
--- a/src/cloudsploit/main.go
+++ b/src/cloudsploit/main.go
@@ -47,7 +47,7 @@ type AppConfig struct {
 	ResultDir      string `required:"true" split_words:"true" default:"/tmp"`
 	ConfigDir      string `required:"true" split_words:"true" default:"/tmp"`
 	CloudsploitDir string `required:"true" split_words:"true" default:"/opt/cloudsploit"`
-	MaxMemSizeMB   int    `split_words:"true"`
+	MaxMemSizeMB   int    `split_words:"true" default:"0"`
 }
 
 func main() {


### PR DESCRIPTION
close https://github.com/ca-risken/internal-community/issues/241

CloudSploitのオプションでMaxMemSizeMBのデフォルト値指定が漏れいていました。この指定がないと起動時にエラーが発生していたためデフォルト値設定します。（0を指定するとサーバ上のデフォルトのJavascriptのヒープサイズで起動する挙動になります）