### PR TITLE
fix: nil pointer exception

### DIFF
--- a/src/portscan/portscan.go
+++ b/src/portscan/portscan.go
@@ -379,6 +379,9 @@ func (p *portscanClient) listLightsail(ctx context.Context) error {
 		return err
 	}
 	for _, i := range result.Instances {
+		if i.PublicIpAddress == nil {
+			continue
+		}
 		for _, n := range (*i.Networking).Ports {
 			if *n.AccessFrom == "Custom" {
 				continue


### PR DESCRIPTION
close https://github.com/ca-risken/internal-community/issues/252
public IP を持たないlightsail インスタンスがあったときにpanicが発生していた模様。
