### PR TITLE
fix: rdsPubliclyAccessible score

### DIFF
--- a/src/cloudsploit/plugin_finding_map.go
+++ b/src/cloudsploit/plugin_finding_map.go
@@ -242,7 +242,7 @@ var cloudSploitFindingMap = map[string]cloudSploitFindingInformation{
 	categoryRDS + "/rdsLoggingEnabled":                    {Score: 3.0, Tags: []string{}},
 	categoryRDS + "/rdsMinorVersionUpgrade":               {Score: 3.0, Tags: []string{"operation"}},
 	categoryRDS + "/rdsMultiAz":                           {Score: 3.0, Tags: []string{"reliability"}},
-	categoryRDS + "/rdsPubliclyAccessible":                {Score: 8.0, Tags: []string{"hipaa", "pci"}},
+	categoryRDS + "/rdsPubliclyAccessible":                {Score: 6.0, Tags: []string{"hipaa", "pci"}},
 	categoryRDS + "/rdsRestorable":                        {Score: 3.0, Tags: []string{"pci", "reliability"}},
 	categoryRDS + "/rdsSnapshotEncryption":                {Score: 3.0, Tags: []string{}},
 	categoryRDS + "/rdsTransportEncryption":               {Score: 3.0, Tags: []string{}},


### PR DESCRIPTION
rdsPubliclyAccessibleのスコアを修正します。
こちらの設定がされていても実際はセキュリティグループで保護されている場合があります。
また、aws:portscan側でインターネットからアクセス可能かを検知しており、より明確なリスクとして検知できるため、こちらのプラグインのスコアを調整します。