### PR TITLE
Resolve missing error in admin checker

### DIFF
--- a/src/admin-checker/admin_checker.go
+++ b/src/admin-checker/admin_checker.go
@@ -150,8 +150,7 @@ func (a *adminCheckerClient) listUser(ctx context.Context) (*[]iamUser, error) {
 		jobID := user.ServiceAccessedReport.JobID
 		accessedDetail, err := a.analyzeServiceLastAccessedDetails(ctx, jobID)
 		if err != nil {
-			appLogger.Warnf(ctx, "Failed to analyzServiceAccessedDetails Job, err=%+v", err.Error())
-			continue
+			return nil, fmt.Errorf("failed analyzeServiceAccessedDetails Job, err=%w", err)
 		}
 		iamUsers[idx].ServiceAccessedReport = *accessedDetail
 		time.Sleep(time.Millisecond * 1000) // For control the API call rating.
@@ -516,8 +515,7 @@ func (a *adminCheckerClient) listRole(ctx context.Context) (*[]iamRole, error) {
 		jobID := role.ServiceAccessedReport.JobID
 		accessedDetail, err := a.analyzeServiceLastAccessedDetails(ctx, jobID)
 		if err != nil {
-			appLogger.Warnf(ctx, "Failed to analyzServiceAccessedDetails Job, err=%+v", err.Error())
-			continue
+			return nil, fmt.Errorf("failed analyzeServiceAccessedDetails Job, err=%w", err)
 		}
 		iamRoles[idx].ServiceAccessedReport = *accessedDetail
 		time.Sleep(time.Millisecond * 1000) // For control the API call rating.

--- a/src/admin-checker/client.go
+++ b/src/admin-checker/client.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/ca-risken/core/proto/alert"
@@ -11,31 +12,28 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-func newFindingClient(svcAddr string) finding.FindingServiceClient {
-	ctx := context.Background()
+func newFindingClient(ctx context.Context, svcAddr string) (finding.FindingServiceClient, error) {
 	conn, err := getGRPCConn(ctx, svcAddr)
 	if err != nil {
-		appLogger.Fatalf(ctx, "Faild to get GRPC connection: err=%+v", err)
+		return nil, fmt.Errorf("failed to get GRPC connection: err=%w", err)
 	}
-	return finding.NewFindingServiceClient(conn)
+	return finding.NewFindingServiceClient(conn), nil
 }
 
-func newAlertClient(svcAddr string) alert.AlertServiceClient {
-	ctx := context.Background()
+func newAlertClient(ctx context.Context, svcAddr string) (alert.AlertServiceClient, error) {
 	conn, err := getGRPCConn(ctx, svcAddr)
 	if err != nil {
-		appLogger.Fatalf(ctx, "Faild to get GRPC connection: err=%+v", err)
+		return nil, fmt.Errorf("failed to get GRPC connection: err=%w", err)
 	}
-	return alert.NewAlertServiceClient(conn)
+	return alert.NewAlertServiceClient(conn), nil
 }
 
-func newAWSClient(svcAddr string) aws.AWSServiceClient {
-	ctx := context.Background()
+func newAWSClient(ctx context.Context, svcAddr string) (aws.AWSServiceClient, error) {
 	conn, err := getGRPCConn(ctx, svcAddr)
 	if err != nil {
-		appLogger.Fatalf(ctx, "Faild to get GRPC connection: err=%+v", err)
+		return nil, fmt.Errorf("failed to get GRPC connection: err=%w", err)
 	}
-	return aws.NewAWSServiceClient(conn)
+	return aws.NewAWSServiceClient(conn), nil
 }
 
 func getGRPCConn(ctx context.Context, addr string) (*grpc.ClientConn, error) {

--- a/src/admin-checker/main.go
+++ b/src/admin-checker/main.go
@@ -114,7 +114,10 @@ func main() {
 		MaxNumberOfMessage: conf.MaxNumberOfMessage,
 		WaitTimeSecond:     conf.WaitTimeSecond,
 	}
-	consumer := newSQSConsumer(ctx, sqsConf)
+	consumer, err := newSQSConsumer(ctx, sqsConf)
+	if err != nil {
+		appLogger.Fatalf(ctx, "Failed to create sqs consumer, err=%+v", err)
+	}
 
 	appLogger.Info(ctx, "Start the AWS IAM AdminChecker SQS consumer server...")
 	consumer.Start(ctx,

--- a/src/admin-checker/main.go
+++ b/src/admin-checker/main.go
@@ -80,12 +80,26 @@ func main() {
 	tracer.Start(tc)
 	defer tracer.Stop()
 
-	handler := &sqsHandler{}
-	handler.findingClient = newFindingClient(conf.CoreSvcAddr)
-	handler.alertClient = newAlertClient(conf.CoreSvcAddr)
-	handler.awsClient = newAWSClient(conf.DataSourceAPISvcAddr)
-	handler.awsRegion = conf.AWSRegion
-	handler.retryMaxAttempts = conf.RetryMaxAttempts
+	fc, err := newFindingClient(ctx, conf.CoreSvcAddr)
+	if err != nil {
+		appLogger.Fatalf(ctx, "Failed to create finding client, err=%+v", err)
+	}
+	ac, err := newAlertClient(ctx, conf.CoreSvcAddr)
+	if err != nil {
+		appLogger.Fatalf(ctx, "Failed to create alert client, err=%+v", err)
+	}
+	awsc, err := newAWSClient(ctx, conf.DataSourceAPISvcAddr)
+	if err != nil {
+		appLogger.Fatalf(ctx, "Failed to create aws client, err=%+v", err)
+	}
+	handler := &sqsHandler{
+		findingClient:    fc,
+		alertClient:      ac,
+		awsClient:        awsc,
+		awsRegion:        conf.AWSRegion,
+		retryMaxAttempts: conf.RetryMaxAttempts,
+	}
+
 	f, err := mimosasqs.NewFinalizer(message.AWSAdminCheckerDataSource, settingURL, conf.CoreSvcAddr, nil)
 	if err != nil {
 		appLogger.Fatalf(ctx, "Failed to create Finalizer, err=%+v", err)

--- a/src/admin-checker/sqs.go
+++ b/src/admin-checker/sqs.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/ca-risken/common/pkg/logging"
 	"github.com/ca-risken/go-sqs-poller/worker/v5"
@@ -19,13 +20,13 @@ type sqsConfig struct {
 	WaitTimeSecond     int32
 }
 
-func newSQSConsumer(ctx context.Context, conf *sqsConfig) *worker.Worker {
+func newSQSConsumer(ctx context.Context, conf *sqsConfig) (*worker.Worker, error) {
 	if conf.Debug == "true" {
 		appLogger.Level(logging.DebugLevel)
 	}
 	sqsClient, err := worker.CreateSqsClient(ctx, conf.AWSRegion, conf.SQSEndpoint)
 	if err != nil {
-		appLogger.Fatalf(ctx, "Failed to create a new client, %v", err)
+		return nil, fmt.Errorf("failed to create a new sqs client, %w", err)
 	}
 	return &worker.Worker{
 		Config: &worker.Config{
@@ -36,5 +37,5 @@ func newSQSConsumer(ctx context.Context, conf *sqsConfig) *worker.Worker {
 		},
 		Log:       appLogger,
 		SqsClient: sqsClient,
-	}
+	}, nil
 }


### PR DESCRIPTION
src/admin-checker配下のエラーハンドリング改善しました。

* client生成時のエラーは呼び出し元でハンドリングするために呼び出し元に返すようにしました。
* handleErrorWithUpdateStatusはステータスの更新とエラーのラッピングという二つの責務を持っていたので、見通しをよくするために分割しました。責務に合わせてメソッド名も変更しています。
* analyzeServicceAccessDetailsの処理がエラーになる場合、呼び出し元でエラーを返すように変更しました。