### PR TITLE
Resolve missing error in cloudsploit

### DIFF
--- a/src/cloudsploit/client.go
+++ b/src/cloudsploit/client.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/ca-risken/core/proto/alert"
@@ -11,34 +12,34 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-func newFindingClient(svcAddr string) finding.FindingServiceClient {
+func newFindingClient(svcAddr string) (finding.FindingServiceClient, error) {
 	ctx := context.Background()
 	conn, err := getGRPCConn(ctx, svcAddr)
 	if err != nil {
-		appLogger.Fatalf(ctx, "Faild to get GRPC connection: err=%+v", err)
+		return nil, fmt.Errorf("failed to get GRPC connection: err=%w", err)
 	}
 	appLogger.Info(ctx, "Start Finding Client")
-	return finding.NewFindingServiceClient(conn)
+	return finding.NewFindingServiceClient(conn), nil
 }
 
-func newAlertClient(svcAddr string) alert.AlertServiceClient {
+func newAlertClient(svcAddr string) (alert.AlertServiceClient, error) {
 	ctx := context.Background()
 	conn, err := getGRPCConn(ctx, svcAddr)
 	if err != nil {
-		appLogger.Fatalf(ctx, "Faild to get GRPC connection: err=%+v", err)
+		return nil, fmt.Errorf("failed to get GRPC connection: err=%w", err)
 	}
 	appLogger.Info(ctx, "Start Alert Client")
-	return alert.NewAlertServiceClient(conn)
+	return alert.NewAlertServiceClient(conn), nil
 }
 
-func newAWSClient(svcAddr string) aws.AWSServiceClient {
+func newAWSClient(svcAddr string) (aws.AWSServiceClient, error) {
 	ctx := context.Background()
 	conn, err := getGRPCConn(ctx, svcAddr)
 	if err != nil {
-		appLogger.Fatalf(ctx, "Faild to get GRPC connection: err=%+v", err)
+		return nil, fmt.Errorf("failed to get GRPC connection: err=%w", err)
 	}
 	appLogger.Info(ctx, "Start AWS Client")
-	return aws.NewAWSServiceClient(conn)
+	return aws.NewAWSServiceClient(conn), nil
 }
 
 func getGRPCConn(ctx context.Context, addr string) (*grpc.ClientConn, error) {

--- a/src/cloudsploit/config.go
+++ b/src/cloudsploit/config.go
@@ -54,7 +54,7 @@ func (c *CloudsploitConfig) createConfigFile(ctx context.Context, accessKeyID, s
 	config = strings.Replace(config, "SECRET_KEY", secretAccessKey, 1)
 	config = strings.Replace(config, "SESSION_TOKEN", sessoinToken, 1)
 	if _, err := file.Write(([]byte)(config)); err != nil {
-		appLogger.Errorf(ctx, "Failed to write file, filename: %s", file.Name())
+		return "", fmt.Errorf("failed to write file, filename: %s, err: %w", file.Name(), err)
 	}
 	return file.Name(), nil
 }

--- a/src/cloudsploit/main.go
+++ b/src/cloudsploit/main.go
@@ -85,16 +85,29 @@ func main() {
 	tracer.Start(tc)
 	defer tracer.Stop()
 
+	findingClient, err := newFindingClient(conf.CoreSvcAddr)
+	if err != nil {
+		appLogger.Fatalf(ctx, "Failed to create finding client, err=%+v", err)
+	}
+	alertClient, err := newAlertClient(conf.CoreSvcAddr)
+	if err != nil {
+		appLogger.Fatalf(ctx, "Failed to create alert client, err=%+v", err)
+	}
+	awsClient, err := newAWSClient(conf.DataSourceAPISvcAddr)
+	if err != nil {
+		appLogger.Fatalf(ctx, "Failed to create aws client, err=%+v", err)
+	}
 	handler := &sqsHandler{
 		resultDir:      conf.ResultDir,
 		configDir:      conf.ConfigDir,
 		cloudsploitDir: conf.CloudsploitDir,
 		awsRegion:      conf.AWSRegion,
 		maxMemSizeMB:   conf.MaxMemSizeMB,
+		findingClient:  findingClient,
+		alertClient:    alertClient,
+		awsClient:      awsClient,
 	}
-	handler.findingClient = newFindingClient(conf.CoreSvcAddr)
-	handler.alertClient = newAlertClient(conf.CoreSvcAddr)
-	handler.awsClient = newAWSClient(conf.DataSourceAPISvcAddr)
+
 	f, err := mimosasqs.NewFinalizer(message.AWSCloudSploitDataSource, settingURL, conf.CoreSvcAddr, nil)
 	if err != nil {
 		appLogger.Fatalf(ctx, "Failed to create Finalizer, err=%+v", err)

--- a/src/cloudsploit/main.go
+++ b/src/cloudsploit/main.go
@@ -122,7 +122,10 @@ func main() {
 		MaxNumberOfMessage: conf.MaxNumberOfMessage,
 		WaitTimeSecond:     conf.WaitTimeSecond,
 	}
-	consumer := newSQSConsumer(ctx, sqsConf)
+	consumer, err := newSQSConsumer(ctx, sqsConf)
+	if err != nil {
+		appLogger.Fatalf(ctx, "Failed to create sqs consumer, err=%+v", err)
+	}
 
 	appLogger.Info(ctx, "Start the cloudsploit SQS consumer server...")
 	consumer.Start(ctx,

--- a/src/cloudsploit/sqs.go
+++ b/src/cloudsploit/sqs.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/ca-risken/common/pkg/logging"
 	"github.com/ca-risken/go-sqs-poller/worker/v5"
@@ -19,13 +20,13 @@ type SQSConfig struct {
 	WaitTimeSecond     int32
 }
 
-func newSQSConsumer(ctx context.Context, conf *SQSConfig) *worker.Worker {
+func newSQSConsumer(ctx context.Context, conf *SQSConfig) (*worker.Worker, error) {
 	if conf.Debug == "true" {
 		appLogger.Level(logging.DebugLevel)
 	}
 	sqsClient, err := worker.CreateSqsClient(ctx, conf.AWSRegion, conf.SQSEndpoint)
 	if err != nil {
-		appLogger.Fatalf(ctx, "Failed to create a new client, %v", err)
+		return nil, fmt.Errorf("failed to create a new sqs client, %w", err)
 	}
 	return &worker.Worker{
 		Config: &worker.Config{
@@ -36,5 +37,5 @@ func newSQSConsumer(ctx context.Context, conf *SQSConfig) *worker.Worker {
 		},
 		Log:       appLogger,
 		SqsClient: sqsClient,
-	}
+	}, nil
 }


### PR DESCRIPTION
* client生成時のエラーは呼び出し元でハンドリングするために呼び出し元に返すようにしています。
* handleErrorWithUpdateStatusはステータスの更新とエラーのラッピングという二つの責務を持っていたので、見通しをよくするために分割しました。責務に合わせてメソッド名も変更しています。
* スキャン用の設定ファイルが作成できない時にエラーを返すようにしました。