### PR TITLE
Resolve missing error in portscan

### DIFF
--- a/src/portscan/client.go
+++ b/src/portscan/client.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/ca-risken/core/proto/alert"
@@ -11,31 +12,31 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-func newFindingClient(svcAddr string) finding.FindingServiceClient {
+func newFindingClient(svcAddr string) (finding.FindingServiceClient, error) {
 	ctx := context.Background()
 	conn, err := getGRPCConn(ctx, svcAddr)
 	if err != nil {
-		appLogger.Fatalf(ctx, "Faild to get GRPC connection: err=%+v", err)
+		return nil, fmt.Errorf("failed to get GRPC connection: err=%w", err)
 	}
-	return finding.NewFindingServiceClient(conn)
+	return finding.NewFindingServiceClient(conn), nil
 }
 
-func newAlertClient(svcAddr string) alert.AlertServiceClient {
+func newAlertClient(svcAddr string) (alert.AlertServiceClient, error) {
 	ctx := context.Background()
 	conn, err := getGRPCConn(ctx, svcAddr)
 	if err != nil {
-		appLogger.Fatalf(ctx, "Faild to get GRPC connection: err=%+v", err)
+		return nil, fmt.Errorf("failed to get GRPC connection: err=%w", err)
 	}
-	return alert.NewAlertServiceClient(conn)
+	return alert.NewAlertServiceClient(conn), nil
 }
 
-func newAWSClient(svcAddr string) aws.AWSServiceClient {
+func newAWSClient(svcAddr string) (aws.AWSServiceClient, error) {
 	ctx := context.Background()
 	conn, err := getGRPCConn(ctx, svcAddr)
 	if err != nil {
-		appLogger.Fatalf(ctx, "Faild to get GRPC connection: err=%+v", err)
+		return nil, fmt.Errorf("failed to get GRPC connection: err=%w", err)
 	}
-	return aws.NewAWSServiceClient(conn)
+	return aws.NewAWSServiceClient(conn), nil
 }
 
 func getGRPCConn(ctx context.Context, addr string) (*grpc.ClientConn, error) {

--- a/src/portscan/main.go
+++ b/src/portscan/main.go
@@ -93,7 +93,10 @@ func main() {
 		WaitTimeSecond:     conf.WaitTimeSecond,
 		ScanConcurrency:    conf.ScanConcurrency,
 	}
-	consumer := newSQSConsumer(ctx, sqsConf)
+	consumer, err := newSQSConsumer(ctx, sqsConf)
+	if err != nil {
+		appLogger.Fatalf(ctx, "Failed to create SQS consumer, err=%+v", err)
+	}
 
 	findingClient, err := newFindingClient(conf.CoreSvcAddr)
 	if err != nil {

--- a/src/portscan/sqs.go
+++ b/src/portscan/sqs.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/ca-risken/common/pkg/logging"
 	"github.com/ca-risken/go-sqs-poller/worker/v5"
 	"golang.org/x/net/context"
@@ -19,13 +21,13 @@ type sqsConfig struct {
 	ScanConcurrency    int64
 }
 
-func newSQSConsumer(ctx context.Context, conf *sqsConfig) *worker.Worker {
+func newSQSConsumer(ctx context.Context, conf *sqsConfig) (*worker.Worker, error) {
 	if conf.Debug == "true" {
 		appLogger.Level(logging.DebugLevel)
 	}
 	sqsClient, err := worker.CreateSqsClient(ctx, conf.AWSRegion, conf.SQSEndpoint)
 	if err != nil {
-		appLogger.Fatalf(ctx, "Failed to create a new client, %v", err)
+		return nil, fmt.Errorf("failed to create a new SQS client, %w", err)
 	}
 	return &worker.Worker{
 		Config: &worker.Config{
@@ -36,5 +38,5 @@ func newSQSConsumer(ctx context.Context, conf *sqsConfig) *worker.Worker {
 		},
 		Log:       appLogger,
 		SqsClient: sqsClient,
-	}
+	}, nil
 }


### PR DESCRIPTION
src/portscan配下のエラーハンドリング改善しました。

* client生成時のエラーは呼び出し元でハンドリングするために呼び出し元に返すようにしています。
* handleErrorWithUpdateStatusはステータスの更新とエラーのラッピングという二つの責務を持っていたので、見通しをよくするために分割しました。責務に合わせてメソッド名も変更しています。
* 検知したfindingsをputする処理でエラーが発生した場合に、スキャン結果をエラーとしました。