### PR TITLE
Remove unused logging

### DIFF
--- a/src/portscan/portscan.go
+++ b/src/portscan/portscan.go
@@ -492,15 +492,7 @@ func scan(ctx context.Context, targets []*target, scanConcurrency int64) ([]*por
 			default:
 				results, err := portscan.Scan(t.Target, t.Protocol, t.FromPort, t.ToPort)
 				if err != nil {
-					// TODO 以下を確認したら、エラーの種類によるハンドリングはせずにそのまま呼び出し元に返すように変更する予定
-					// 握りつぶしていたエラーを返すようにしたが、そのエラーがどれくらい発生していたかが不明なためそのままエラーを返すとオペレーションの負荷が高くなる可能性がある。
-					// 発生件数を確認するためにログ出力だけを行いエラーは返さずに終了させる。
-					if _, ok := err.(*portscan.ResultAnalysisError); ok {
-						appLogger.Warnf(ctx, "Failed to analyze portscan results, err=%+v", err)
-						return nil
-					} else {
-						return err
-					}
+					return err
 				}
 				for _, result := range results {
 					result.ResourceName = t.Arn


### PR DESCRIPTION
https://github.com/ca-risken/aws/pull/249 で追加した影響確認用のログを削除して、portscanによるスキャンでエラーが発生した際に一律エラーを返すように変更します。
ここ一週間で該当のログはなかったので、運用への影響はないです。