### PR TITLE
add: control retry aws api

### DIFF
--- a/src/guard-duty/guardduty.go
+++ b/src/guard-duty/guardduty.go
@@ -32,15 +32,15 @@ type guardDutyClient struct {
 	EC2 *ec2.Client
 }
 
-func newGuardDutyClient(ctx context.Context, region, assumeRole, externalID string) (guardDutyAPI, error) {
+func newGuardDutyClient(ctx context.Context, region, assumeRole, externalID string, retry int) (guardDutyAPI, error) {
 	g := guardDutyClient{}
-	if err := g.newAWSSession(ctx, region, assumeRole, externalID); err != nil {
+	if err := g.newAWSSession(ctx, region, assumeRole, externalID, retry); err != nil {
 		return nil, err
 	}
 	return &g, nil
 }
 
-func (g *guardDutyClient) newAWSSession(ctx context.Context, region, assumeRole, externalID string) error {
+func (g *guardDutyClient) newAWSSession(ctx context.Context, region, assumeRole, externalID string, retry int) error {
 	if assumeRole == "" {
 		return errors.New("required AWS AssumeRole")
 	}
@@ -63,8 +63,8 @@ func (g *guardDutyClient) newAWSSession(ctx context.Context, region, assumeRole,
 	if err != nil {
 		return err
 	}
-	g.Svc = guardduty.New(guardduty.Options{Credentials: cfg.Credentials, Region: region})
-	g.EC2 = ec2.New(ec2.Options{Credentials: cfg.Credentials, Region: region})
+	g.Svc = guardduty.New(guardduty.Options{Credentials: cfg.Credentials, Region: region, RetryMaxAttempts: retry})
+	g.EC2 = ec2.New(ec2.Options{Credentials: cfg.Credentials, Region: region, RetryMaxAttempts: retry})
 	return nil
 }
 

--- a/src/guard-duty/main.go
+++ b/src/guard-duty/main.go
@@ -37,6 +37,7 @@ type AppConfig struct {
 	AWSGuardDutyQueueURL  string `split_words:"true" default:"http://queue.middleware.svc.cluster.local:9324/queue/aws-guardduty"`
 	MaxNumberOfMessage    int32  `split_words:"true" default:"10"`
 	WaitTimeSecond        int32  `split_words:"true" default:"20"`
+	RetryMaxAttempts      int    `split_words:"true" default:"10"`
 
 	// grpc
 	CoreSvcAddr          string `required:"true" split_words:"true" default:"core.core.svc.cluster.local:8080"`
@@ -106,10 +107,11 @@ func main() {
 		appLogger.Fatalf(ctx, "Failed to create aws client, err=%+v", err)
 	}
 	handler := &sqsHandler{
-		awsRegion:     conf.AWSRegion,
-		findingClient: findingClient,
-		alertClient:   alertClient,
-		awsClient:     awsClient,
+		awsRegion:        conf.AWSRegion,
+		findingClient:    findingClient,
+		alertClient:      alertClient,
+		awsClient:        awsClient,
+		retryMaxAttempts: conf.RetryMaxAttempts,
 	}
 
 	f, err := mimosasqs.NewFinalizer(message.AWSGuardDutyDataSource, settingURL, conf.CoreSvcAddr, nil)

--- a/src/portscan/main.go
+++ b/src/portscan/main.go
@@ -45,6 +45,7 @@ type AppConfig struct {
 	// portsan
 	ScanExcludePortNumber int   `split_words:"true" default:"1000"`
 	ScanConcurrency       int64 `split_words:"true" default:"5"`
+	RetryMaxAttempts      int   `split_words:"true" default:"10"`
 }
 
 func main() {
@@ -117,6 +118,7 @@ func main() {
 		findingClient:         findingClient,
 		alertClient:           alertClient,
 		awsClient:             awsClient,
+		retryMaxAttempts:      conf.RetryMaxAttempts,
 	}
 	f, err := mimosasqs.NewFinalizer(message.AWSPortscanDataSource, settingURL, conf.CoreSvcAddr, nil)
 	if err != nil {

--- a/src/portscan/portscan.go
+++ b/src/portscan/portscan.go
@@ -48,16 +48,16 @@ type portscanClient struct {
 	Region               string
 }
 
-func newPortscanClient(ctx context.Context, region, assumeRole, externalID string, scanExcludePortNumber int) (portscanAPI, error) {
+func newPortscanClient(ctx context.Context, region, assumeRole, externalID string, scanExcludePortNumber, retry int) (portscanAPI, error) {
 	p := portscanClient{}
-	if err := p.newAWSSession(ctx, region, assumeRole, externalID); err != nil {
+	if err := p.newAWSSession(ctx, region, assumeRole, externalID, retry); err != nil {
 		return nil, err
 	}
 	p.Region = region
 	return &p, nil
 }
 
-func (p *portscanClient) newAWSSession(ctx context.Context, region, assumeRole, externalID string) error {
+func (p *portscanClient) newAWSSession(ctx context.Context, region, assumeRole, externalID string, retry int) error {
 	if assumeRole == "" {
 		return errors.New("Required AWS AssumeRole")
 	}
@@ -80,11 +80,11 @@ func (p *portscanClient) newAWSSession(ctx context.Context, region, assumeRole, 
 	if err != nil {
 		return err
 	}
-	p.EC2 = ec2.New(ec2.Options{Credentials: cfg.Credentials, Region: region})
-	p.ELB = elb.New(elb.Options{Credentials: cfg.Credentials, Region: region})
-	p.ELBv2 = elbv2.New(elbv2.Options{Credentials: cfg.Credentials, Region: region})
-	p.RDS = rds.New(rds.Options{Credentials: cfg.Credentials, Region: region})
-	p.Lightsail = lightsail.New(lightsail.Options{Credentials: cfg.Credentials, Region: region})
+	p.EC2 = ec2.New(ec2.Options{Credentials: cfg.Credentials, Region: region, RetryMaxAttempts: retry})
+	p.ELB = elb.New(elb.Options{Credentials: cfg.Credentials, Region: region, RetryMaxAttempts: retry})
+	p.ELBv2 = elbv2.New(elbv2.Options{Credentials: cfg.Credentials, Region: region, RetryMaxAttempts: retry})
+	p.RDS = rds.New(rds.Options{Credentials: cfg.Credentials, Region: region, RetryMaxAttempts: retry})
+	p.Lightsail = lightsail.New(lightsail.Options{Credentials: cfg.Credentials, Region: region, RetryMaxAttempts: retry})
 	return nil
 }
 


### PR DESCRIPTION
guarddutyとportscanにRetryMaxAttemptsの機構を導入します。
AWS側の一時的なエラーの影響を受けにくくする目的です。