### PR TITLE
fix scan target protocol

### DIFF
--- a/src/portscan/portscan.go
+++ b/src/portscan/portscan.go
@@ -153,6 +153,10 @@ func (p *portscanClient) listSecurityGroup(ctx context.Context, accountID string
 		tPort := 65535
 		ipProtocol := "all"
 		for _, ipPermission := range securityGroup.IpPermissions {
+			// skip scan without tcp,udp and all
+			if *ipPermission.IpProtocol != "tcp" && *ipPermission.IpProtocol == "udp" && *ipPermission.IpProtocol != "-1" {
+				continue
+			}
 			if *ipPermission.IpProtocol == "tcp" || *ipPermission.IpProtocol == "udp" {
 				fPort = int(*ipPermission.FromPort)
 				tPort = int(*ipPermission.ToPort)

--- a/src/portscan/portscan.go
+++ b/src/portscan/portscan.go
@@ -139,6 +139,8 @@ func (p *portscanClient) getTargets(ctx context.Context, message *message.AWSQue
 	return p.target, p.relSecurityGroupARNs, nil
 }
 
+const IP_PROTOCOL_ALL = "-1"
+
 func (p *portscanClient) listSecurityGroup(ctx context.Context, accountID string) error {
 	var retSG []*targetSG
 	allSecurityGroup := map[string]*relSecurityGroupArn{}
@@ -154,7 +156,7 @@ func (p *portscanClient) listSecurityGroup(ctx context.Context, accountID string
 		ipProtocol := "all"
 		for _, ipPermission := range securityGroup.IpPermissions {
 			// skip scan without tcp,udp and all
-			if *ipPermission.IpProtocol != "tcp" && *ipPermission.IpProtocol == "udp" && *ipPermission.IpProtocol != "-1" {
+			if *ipPermission.IpProtocol != "tcp" && *ipPermission.IpProtocol != "udp" && *ipPermission.IpProtocol != IP_PROTOCOL_ALL {
 				continue
 			}
 			if *ipPermission.IpProtocol == "tcp" || *ipPermission.IpProtocol == "udp" {


### PR DESCRIPTION
udp,tcp,all以外のIpProtocolが設定されている際にスキャン対象をallと同等に扱ってしまう問題を修正します