### PR TITLE
fix portscan

### DIFF
--- a/pkg/portscan/portscan.go
+++ b/pkg/portscan/portscan.go
@@ -131,12 +131,13 @@ func (p *portscanClient) getTargets(ctx context.Context, message *message.AWSQue
 		p.logger.Errorf(ctx, "Failed to describeDBInstances(rds): err=%+v", err)
 		return []*target{}, map[string]*relSecurityGroupArn{}, err
 	}
-	if isAvailableRegionLightSail(p.Region) {
-		err = p.listLightsail(ctx)
-		if err != nil {
-			p.logger.Errorf(ctx, "Failed to getInstances(lightsail): err=%+v", err)
-			return []*target{}, map[string]*relSecurityGroupArn{}, err
-		}
+	if !isAvailableRegionLightSail(p.Region) {
+		return p.target, p.relSecurityGroupARNs, nil
+	}
+	err = p.listLightsail(ctx)
+	if err != nil {
+		p.logger.Errorf(ctx, "Failed to getInstances(lightsail): err=%+v", err)
+		return []*target{}, map[string]*relSecurityGroupArn{}, err
 	}
 
 	return p.target, p.relSecurityGroupARNs, nil

--- a/pkg/portscan/portscan.go
+++ b/pkg/portscan/portscan.go
@@ -60,14 +60,16 @@ func newPortscanClient(ctx context.Context, region, assumeRole, externalID strin
 	return &p, nil
 }
 
+const REGION_US_EAST_1 = "us-east-1"
+
 func (p *portscanClient) newAWSSession(ctx context.Context, region, assumeRole, externalID string, retry int) error {
 	if assumeRole == "" {
-		return errors.New("Required AWS AssumeRole")
+		return errors.New("required AWS AssumeRole")
 	}
 	if externalID == "" {
-		return errors.New("Required AWS ExternalID")
+		return errors.New("required AWS ExternalID")
 	}
-	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(REGION_US_EAST_1))
 	if err != nil {
 		return err
 	}
@@ -129,13 +131,11 @@ func (p *portscanClient) getTargets(ctx context.Context, message *message.AWSQue
 		p.logger.Errorf(ctx, "Failed to describeDBInstances(rds): err=%+v", err)
 		return []*target{}, map[string]*relSecurityGroupArn{}, err
 	}
-	err = p.listLightsail(ctx)
-	if err != nil {
-		if isAvailableRegionLightSail(p.Region) {
+	if isAvailableRegionLightSail(p.Region) {
+		err = p.listLightsail(ctx)
+		if err != nil {
 			p.logger.Errorf(ctx, "Failed to getInstances(lightsail): err=%+v", err)
 			return []*target{}, map[string]*relSecurityGroupArn{}, err
-		} else {
-			p.logger.Infof(ctx, "Failed to getInstances(lightsail). but region %v is not supported LightSail", p.Region)
 		}
 	}
 

--- a/pkg/portscan/services_region.go
+++ b/pkg/portscan/services_region.go
@@ -14,6 +14,7 @@ var LightSailRegions = []string{
 	"eu-west-1",
 	"eu-west-2",
 	"eu-west-3",
+	"eu-north-1",
 }
 
 func isAvailableRegionLightSail(region string) bool {


### PR DESCRIPTION
STSのエンドポイントを常にアクティブになるus-east-1へ変更します

lightsailで使用できないregionの確認をlightsailのAPIを叩く前に行うように修正します

lightsailの利用可能regionを追加しました