### PR TITLE
fix: credentials error handling

### DIFF
--- a/pkg/cloudsploit/config.go
+++ b/pkg/cloudsploit/config.go
@@ -23,7 +23,7 @@ func (c *CloudsploitConfig) generate(ctx context.Context, assumeRole, externalID
 	}
 	creds, err := getCredential(ctx, assumeRole, externalID, time.Duration(3600)*time.Second) // MaxSessionDuration(for API): min=3600, max=3600
 	if err != nil {
-		return err
+		return fmt.Errorf("credential error: %w", err)
 	}
 	c.ConfigPath, err = c.createConfigFile(ctx, creds.AccessKeyID, creds.SecretAccessKey, creds.SessionToken, awsID, accountID)
 	return err

--- a/pkg/cloudsploit/handler.go
+++ b/pkg/cloudsploit/handler.go
@@ -70,7 +70,7 @@ func (s *SqsHandler) HandleMessage(ctx context.Context, sqsMsg *types.Message) e
 
 	err = s.cloudsploitConf.generate(ctx, msg.AssumeRoleArn, msg.ExternalID, msg.AWSID, msg.AccountID)
 	if err != nil {
-		s.logger.Errorf(ctx, "Error occured when configure: %v, error: %v", msg, err)
+		s.updateStatusToError(ctx, &status, err)
 		return mimosasqs.WrapNonRetryable(err)
 	}
 


### PR DESCRIPTION
設定済みのAssumeRoleやExternalIDでセッションが取得できなかった場合にエラーステータスに更新するようにします。