### PR TITLE
fix: scan detail

### DIFF
--- a/pkg/accessanalyzer/handler.go
+++ b/pkg/accessanalyzer/handler.go
@@ -183,9 +183,6 @@ func (s *SqsHandler) tagFinding(ctx context.Context, tag string, findingID uint6
 
 func (s *SqsHandler) updateScanStatusError(ctx context.Context, status *awsClient.AttachDataSourceRequest, statusDetail string) error {
 	status.AttachDataSource.Status = awsClient.Status_ERROR
-	if len(statusDetail) > 200 {
-		statusDetail = statusDetail[:200] + " ..." // cut long text
-	}
 	status.AttachDataSource.StatusDetail = statusDetail
 	return s.attachAWSStatus(ctx, status)
 }

--- a/pkg/adminchecker/handler.go
+++ b/pkg/adminchecker/handler.go
@@ -255,9 +255,6 @@ func (s *SqsHandler) tagFinding(ctx context.Context, tag string, findingID uint6
 
 func (s *SqsHandler) updateScanStatusError(ctx context.Context, status *awsClient.AttachDataSourceRequest, statusDetail string) error {
 	status.AttachDataSource.Status = awsClient.Status_ERROR
-	if len(statusDetail) > 200 {
-		statusDetail = statusDetail[:200] + " ..." // cut long text
-	}
 	status.AttachDataSource.StatusDetail = statusDetail
 	return s.attachAWSStatus(ctx, status)
 }

--- a/pkg/cloudsploit/cloudsploit.go
+++ b/pkg/cloudsploit/cloudsploit.go
@@ -107,3 +107,25 @@ type cloudSploitResult struct {
 	Status      string
 	Message     string
 }
+
+const (
+	STATUS_UNKNOWN = "UNKNOWN"
+	WARN_MESSAGE   = "UNKNOWN status detected. Some scans may have failed. Please take action if you don't have enough permissions."
+)
+
+func unknownFindings(findings *[]cloudSploitResult) string {
+	unknowns := map[string]int{}
+	for _, f := range *findings {
+		if f.Status == STATUS_UNKNOWN {
+			unknowns[fmt.Sprintf("%s: %s", f.Category, f.Message)]++
+		}
+	}
+	statusDetail := ""
+	for k, v := range unknowns {
+		statusDetail += fmt.Sprintf("%s (%d)\n", k, v)
+	}
+	if statusDetail != "" {
+		statusDetail = fmt.Sprintf("%s\n\n%s", WARN_MESSAGE, statusDetail)
+	}
+	return statusDetail
+}

--- a/pkg/cloudsploit/cloudsploit.go
+++ b/pkg/cloudsploit/cloudsploit.go
@@ -121,8 +121,8 @@ func unknownFindings(findings *[]cloudSploitResult) string {
 		}
 	}
 	statusDetail := ""
-	for k, v := range unknowns {
-		statusDetail += fmt.Sprintf("%s (%d)\n", k, v)
+	for k := range unknowns {
+		statusDetail += fmt.Sprintf("- %s\n", k)
 	}
 	if statusDetail != "" {
 		statusDetail = fmt.Sprintf("%s\n\n%s", WARN_MESSAGE, statusDetail)

--- a/pkg/cloudsploit/handler.go
+++ b/pkg/cloudsploit/handler.go
@@ -131,21 +131,14 @@ func (s *SqsHandler) updateStatusToError(ctx context.Context, scanStatus *awsCli
 
 func (s *SqsHandler) updateScanStatusError(ctx context.Context, status *awsClient.AttachDataSourceRequest, statusDetail string) error {
 	status.AttachDataSource.Status = awsClient.Status_ERROR
-	status.AttachDataSource.StatusDetail = cutStatusDetail(statusDetail)
+	status.AttachDataSource.StatusDetail = statusDetail
 	return s.attachAWSStatus(ctx, status)
 }
 
 func (s *SqsHandler) updateScanStatusSuccess(ctx context.Context, status *awsClient.AttachDataSourceRequest, statusDetail string) error {
 	status.AttachDataSource.Status = awsClient.Status_OK
-	status.AttachDataSource.StatusDetail = cutStatusDetail(statusDetail)
+	status.AttachDataSource.StatusDetail = statusDetail
 	return s.attachAWSStatus(ctx, status)
-}
-
-func cutStatusDetail(s string) string {
-	if len(s) > 240 {
-		s = s[:240] + " ..." // cut long text
-	}
-	return s
 }
 
 func (s *SqsHandler) attachAWSStatus(ctx context.Context, status *awsClient.AttachDataSourceRequest) error {

--- a/pkg/guardduty/handler.go
+++ b/pkg/guardduty/handler.go
@@ -219,9 +219,6 @@ func (s *SqsHandler) tagFinding(ctx context.Context, tag string, findingID uint6
 
 func (s *SqsHandler) updateScanStatusError(ctx context.Context, status *awsClient.AttachDataSourceRequest, statusDetail string) error {
 	status.AttachDataSource.Status = awsClient.Status_ERROR
-	if len(statusDetail) > 200 {
-		statusDetail = statusDetail[:200] + " ..." // cut long text
-	}
 	status.AttachDataSource.StatusDetail = statusDetail
 	return s.attachAWSStatus(ctx, status)
 }

--- a/pkg/portscan/handler.go
+++ b/pkg/portscan/handler.go
@@ -180,9 +180,6 @@ func (s *SqsHandler) updateStatusToError(ctx context.Context, scanStatus *awsCli
 
 func (s *SqsHandler) updateScanStatusError(ctx context.Context, status *awsClient.AttachDataSourceRequest, statusDetail string) error {
 	status.AttachDataSource.Status = awsClient.Status_ERROR
-	if len(statusDetail) > 200 {
-		statusDetail = statusDetail[:200] + " ..." // cut long text
-	}
 	status.AttachDataSource.StatusDetail = statusDetail
 	return s.attachAWSStatus(ctx, status)
 }


### PR DESCRIPTION
cloudsploit scanでUNKNOWNステータスが合った場合にはscan detailに内容を記載するようにします。