### PR TITLE
update: aws cloudsploit

### DIFF
--- a/dockers/cloudsploit/Dockerfile
+++ b/dockers/cloudsploit/Dockerfile
@@ -6,8 +6,25 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -buildvcs=false -o /go/bin/cloudsploit cmd/cloudsploit/main.go
 
-FROM public.ecr.aws/risken/base/cloudsploit-base:v0.0.1
+FROM node:lts-alpine3.12 as cloudsploit
+# 2023/03/20時点で最新
+ARG CLOUDSPLOIT_COMMIT_HASH=3d5f72d46e495ffcb8d9ebf44e60b6551fddbf4e
+RUN apk add --no-cache ca-certificates tzdata git \
+  && mkdir -p /opt/cloudsploit \
+  && cd /opt/cloudsploit \
+  && git init \
+  && git remote add origin https://github.com/aquasecurity/cloudsploit.git \
+  && git fetch origin ${CLOUDSPLOIT_COMMIT_HASH} --depth 1 \
+  && git checkout FETCH_HEAD \
+  && yarn install  \
+  && chmod +x index.js
+
+FROM public.ecr.aws/risken/base/risken-base:v0.0.1 as risken-base
+
+FROM node:lts-alpine3.12
 COPY --from=builder /go/bin/cloudsploit /usr/local/cloudsploit/bin/
+COPY --from=cloudsploit /opt/cloudsploit /opt/cloudsploit
+COPY --from=risken-base /usr/local/bin/env-injector /usr/local/bin/
 ENV DEBUG= \
   PROFILE_EXPORTER= \
   PROFILE_TYPES= \

--- a/pkg/cloudsploit/cloudsploit.go
+++ b/pkg/cloudsploit/cloudsploit.go
@@ -99,8 +99,9 @@ type cloudSploitResult struct {
 }
 
 const (
-	STATUS_UNKNOWN = "UNKNOWN"
-	WARN_MESSAGE   = "UNKNOWN status detected. Some scans may have failed. Please take action if you don't have enough permissions."
+	STATUS_UNKNOWN                 = "UNKNOWN"
+	WARN_MESSAGE                   = "UNKNOWN status detected. Some scans may have failed. Please take action if you don't have enough permissions."
+	STATUS_DETAIL_LENGTH_THRESHOLD = 30000
 )
 
 func unknownFindings(findings *[]cloudSploitResult) string {
@@ -111,8 +112,15 @@ func unknownFindings(findings *[]cloudSploitResult) string {
 		}
 	}
 	statusDetail := ""
+	statusDetailLen := 0
 	for k := range unknowns {
-		statusDetail += fmt.Sprintf("- %s\n", k)
+		unknown := fmt.Sprintf("- %s\n", k)
+		statusDetail += unknown
+		statusDetailLen += len(unknown)
+		if statusDetailLen >= STATUS_DETAIL_LENGTH_THRESHOLD {
+			statusDetail += " ..."
+			break
+		}
 	}
 	if statusDetail != "" {
 		statusDetail = fmt.Sprintf("%s\n\n%s", WARN_MESSAGE, statusDetail)

--- a/pkg/cloudsploit/cloudsploit.go
+++ b/pkg/cloudsploit/cloudsploit.go
@@ -112,12 +112,10 @@ func unknownFindings(findings *[]cloudSploitResult) string {
 		}
 	}
 	statusDetail := ""
-	statusDetailLen := 0
 	for k := range unknowns {
 		unknown := fmt.Sprintf("- %s\n", k)
 		statusDetail += unknown
-		statusDetailLen += len(unknown)
-		if statusDetailLen >= STATUS_DETAIL_LENGTH_THRESHOLD {
+		if STATUS_DETAIL_LENGTH_THRESHOLD <= len(statusDetail) {
 			statusDetail += " ..."
 			break
 		}


### PR DESCRIPTION
cloudsploitを最新にアップデートします
- ビルド時間を計測する目的でbase-imageをpullする箇所を外します
- status_detailの値がmysqlのtext型65,535バイトを超過するケースがあったので、閾値を設定するようにしました