### PR TITLE
ignore: managed iam roles

### DIFF
--- a/pkg/cloudsploit/finding.go
+++ b/pkg/cloudsploit/finding.go
@@ -191,6 +191,10 @@ func getScore(result *cloudSploitResult) float32 {
 		if isSecurityGroupResource(result) && len(result.SecurityGroupAttachedResources) == 0 {
 			return 1.0 // security group finding, but no attached resources(almost no risk).
 		}
+		// Check IAM Role Findings ...
+		if common.IsManagedIAMRole(result.Resource) {
+			return 1.0 // Managed iam role finding (User has no control).
+		}
 
 		findingInf, ok := cloudSploitFindingMap[fmt.Sprintf("%s/%s", result.Category, result.Plugin)]
 		if ok {

--- a/pkg/cloudsploit/finding_test.go
+++ b/pkg/cloudsploit/finding_test.go
@@ -93,6 +93,18 @@ func TestGetScore(t *testing.T) {
 			},
 			want: 1.0,
 		},
+		{
+			name: "Fail iamRoleLastUsed but managed role",
+			input: &cloudSploitResult{
+				Status:    "FAIL",
+				Category:  "IAM",
+				Plugin:    "iamRoleLastUsed",
+				Region:    "ap-northeast-1",
+				AccountID: "123456789012",
+				Resource:  "arn:aws:iam::123456789012:role/aws-service-role/managed-role",
+			},
+			want: 1.0,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/pkg/common/util.go
+++ b/pkg/common/util.go
@@ -34,3 +34,7 @@ func IsMatchAccountIDArn(accountID, arn string) bool {
 	tmp := strings.Split(arn, "::")[1]
 	return strings.HasPrefix(tmp, accountID)
 }
+
+func IsManagedIAMRole(arn string) bool {
+	return strings.HasPrefix(arn, "arn:aws:iam::") && strings.Contains(arn, ":role/aws-service-role/")
+}

--- a/pkg/common/util_test.go
+++ b/pkg/common/util_test.go
@@ -45,3 +45,35 @@ func TestIsMatchAccountIDArn(t *testing.T) {
 		})
 	}
 }
+
+func TestIsManagedIAMRole(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{
+			name:  "OK",
+			input: "arn:aws:iam::123456789012:role/aws-service-role/inspector2.amazonaws.com/AWSServiceRoleForAmazonInspector2",
+			want:  true,
+		},
+		{
+			name:  "Custom Role",
+			input: "arn:aws:iam::123456789012:role/custom-role",
+			want:  false,
+		},
+		{
+			name:  "Not IAM Role",
+			input: "arn:aws:unknown::123456789012:role/aws-service-role/unknown-role",
+			want:  false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := IsManagedIAMRole(c.input)
+			if c.want != got {
+				t.Fatalf("Unexpected resource name: want=%v, got=%v", c.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
ユーザが基本コントロール外であるマネージドIAMロールのFindingのスコアを下げます