### PR TITLE
[CloudSploit] skipResourceNamePatternオプションのサポート

### DIFF
--- a/cloudsploit.yaml
+++ b/cloudsploit.yaml
@@ -712,6 +712,26 @@ specificPluginSetting:
       recommendation: |-
         Restrict TCP ports 20 and 21 to known IP addresses
         - http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/authorizing-access-to-an-instance.html
+  EC2/openHTTP:
+    score: 3
+    recommend:
+      risk: |-
+        Open HTTP
+        - Determine if TCP port 80 for HTTP is open to the public
+        - While some ports are required to be open to the public to function properly, more sensitive services such as HTTP should be restricted to known IP addresses.
+      recommendation: |-
+        Restrict TCP port 80 to known IP addresses
+        - http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/authorizing-access-to-an-instance.html
+  EC2/openHTTPS:
+    score: 3
+    recommend:
+      risk: |-
+        Open HTTPS
+        - Determine if TCP port 443 for HTTPS is open to the public
+        - While some ports are required to be open to the public to function properly, more sensitive services such as HTTPS should be restricted to known IP addresses.
+      recommendation: |-
+        Restrict TCP port 443 to known IP addresses.
+        - http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/authorizing-access-to-an-instance.html
   EC2/openHadoopNameNode:
     score: 8
     recommend:

--- a/cloudsploit.yaml
+++ b/cloudsploit.yaml
@@ -1,7 +1,13 @@
 defaultScore: 3
 
 ignorePlugin:
-  - ecr/ecrRepositoryPolicy # Supported by access-analyzer
+  # Supported by access-analyzer
+  - ecr/ecrRepositoryPolicy
+  - EC2/ebsSnapshotPublic
+  - Lambda/lambdaPublicAccess
+  - RDS/rdsSnapshotPubliclyAccessible
+  - SNS/topicPolicies
+  - SQS/sqsPublicAccess
 
 specificPluginSetting:
   # aaaPlugin:

--- a/pkg/cloudsploit/cloudsploit_test.go
+++ b/pkg/cloudsploit/cloudsploit_test.go
@@ -78,3 +78,65 @@ func TestRemoveIgnorePlugin(t *testing.T) {
 		})
 	}
 }
+
+func TestIsSecurityGroupResource(t *testing.T) {
+	tests := []struct {
+		name   string
+		result *cloudSploitResult
+		want   bool
+	}{
+		{
+			name: "OK",
+			result: &cloudSploitResult{
+				Resource:  "arn:aws:ec2:us-west-2:123456789012:security-group/sg-12345678",
+				Region:    "us-west-2",
+				AccountID: "123456789012",
+			},
+			want: true,
+		},
+		{
+			name: "Invalid region",
+			result: &cloudSploitResult{
+				Resource:  "arn:aws:ec2:us-east-1:123456789012:security-group/sg-12345678",
+				Region:    "us-west-2",
+				AccountID: "123456789012",
+			},
+			want: false,
+		},
+		{
+			name: "Invalid account ID",
+			result: &cloudSploitResult{
+				Resource:  "arn:aws:ec2:us-west-2:987654321098:security-group/sg-12345678",
+				Region:    "us-west-2",
+				AccountID: "123456789012",
+			},
+			want: false,
+		},
+		{
+			name: "Not security group resource",
+			result: &cloudSploitResult{
+				Resource:  "arn:aws:s3:::my-bucket",
+				Region:    "us-west-2",
+				AccountID: "123456789012",
+			},
+			want: false,
+		},
+		{
+			name: "Invalid security group ID",
+			result: &cloudSploitResult{
+				Resource:  "arn:aws:ec2:us-west-2:123456789012:security-group/invalid-12345678",
+				Region:    "us-west-2",
+				AccountID: "123456789012",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isSecurityGroupResource(tt.result); got != tt.want {
+				t.Errorf("isSecurityGroupResource() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/cloudsploit/setting.go
+++ b/pkg/cloudsploit/setting.go
@@ -84,12 +84,15 @@ func (c *CloudsploitSetting) IsIgnorePlugin(plugin string) bool {
 	return slices.Contains(c.IgnorePlugin, plugin)
 }
 
-func (c *CloudsploitSetting) IsSkipResourceNamePattern(plugin string, resourceName string) bool {
+func (c *CloudsploitSetting) IsSkipResourceNamePattern(plugin, resourceName, aliasResourceName string) bool {
 	if c.SpecificPluginSetting[plugin].SkipResourceNamePattern == nil {
 		return false
 	}
 	for _, pattern := range c.SpecificPluginSetting[plugin].SkipResourceNamePattern {
 		if strings.Contains(resourceName, pattern) {
+			return true
+		}
+		if aliasResourceName != "" && strings.Contains(aliasResourceName, pattern) {
 			return true
 		}
 	}

--- a/pkg/cloudsploit/setting_test.go
+++ b/pkg/cloudsploit/setting_test.go
@@ -140,9 +140,10 @@ func TestIsIgnorePlugin(t *testing.T) {
 
 func TestIsSkipResourceNamePattern(t *testing.T) {
 	type args struct {
-		setting      *CloudsploitSetting
-		plugin       string
-		resourceName string
+		setting           *CloudsploitSetting
+		plugin            string
+		resourceName      string
+		aliasResourceName string
 	}
 	tests := []struct {
 		name  string
@@ -159,8 +160,25 @@ func TestIsSkipResourceNamePattern(t *testing.T) {
 						},
 					},
 				},
-				plugin:       "plugin1",
-				resourceName: "testResourceName",
+				plugin:            "plugin1",
+				resourceName:      "testResourceName",
+				aliasResourceName: "alias",
+			},
+			want: true,
+		},
+		{
+			name: "Skip alias name pattern matches",
+			input: args{
+				setting: &CloudsploitSetting{
+					SpecificPluginSetting: map[string]PluginSetting{
+						"plugin1": {
+							SkipResourceNamePattern: []string{"ignore", "test"},
+						},
+					},
+				},
+				plugin:            "plugin1",
+				resourceName:      "ResourceName",
+				aliasResourceName: "ignoreAlias",
 			},
 			want: true,
 		},
@@ -174,8 +192,9 @@ func TestIsSkipResourceNamePattern(t *testing.T) {
 						},
 					},
 				},
-				plugin:       "plugin1",
-				resourceName: "resourceName",
+				plugin:            "plugin1",
+				resourceName:      "resourceName",
+				aliasResourceName: "alias",
 			},
 			want: false,
 		},
@@ -187,8 +206,9 @@ func TestIsSkipResourceNamePattern(t *testing.T) {
 						"plugin1": {},
 					},
 				},
-				plugin:       "plugin1",
-				resourceName: "resourceName",
+				plugin:            "plugin1",
+				resourceName:      "resourceName",
+				aliasResourceName: "alias",
 			},
 			want: false,
 		},
@@ -198,8 +218,9 @@ func TestIsSkipResourceNamePattern(t *testing.T) {
 				setting: &CloudsploitSetting{
 					SpecificPluginSetting: map[string]PluginSetting{},
 				},
-				plugin:       "plugin1",
-				resourceName: "resourceName",
+				plugin:            "plugin1",
+				resourceName:      "resourceName",
+				aliasResourceName: "alias",
 			},
 			want: false,
 		},
@@ -207,7 +228,7 @@ func TestIsSkipResourceNamePattern(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.input.setting.IsSkipResourceNamePattern(tt.input.plugin, tt.input.resourceName); got != tt.want {
+			if got := tt.input.setting.IsSkipResourceNamePattern(tt.input.plugin, tt.input.resourceName, tt.input.aliasResourceName); got != tt.want {
 				t.Errorf("IsSkipResourceNamePattern() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
以下の修正を行いました
-  AccessAnalyzerと重複しているプラグインはcloudsploit.yamlで除外
-  cloudsploit.yamlで `skipResourceNamePattern` オプションをサポート
- セキュリティグループの場合にはSG名を取得（skipResourceNamePatternの判定で利用できるようにするため）
- 既存のバグ修正（セキュリティグループかの判定がミスってた）
