### PR TITLE
fix: go install

### DIFF
--- a/codebuild/multi-arch/buildspec-image.yml
+++ b/codebuild/multi-arch/buildspec-image.yml
@@ -3,6 +3,7 @@ version: 0.2
 env:
   variables:
     IMAGE_PREFIX: "risken-aws"
+    GO_VERSION: "1.21.3"
   parameter-store:
     DOCKER_USER: "/build/DOCKER_USER"
     DOCKER_TOKEN: "/build/DOCKER_TOKEN"
@@ -15,7 +16,7 @@ phases:
       - TAG=$(git rev-parse --short HEAD)_${OS}_${ARCH}
       - AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query 'Account' --output text)
       - REGISTRY=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com
-      - sh codebuild/multi-arch/install-go.sh
+      - GO_VERSION=${GO_VERSION} sh codebuild/multi-arch/install-go.sh
       - go version
 
       - echo Logging in to Amazon ECR...

--- a/codebuild/multi-arch/install-go.sh
+++ b/codebuild/multi-arch/install-go.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
-INSTALL_GO_VERSION=1.21.3
+# If GO_VERSION is not set, use DEFAULT_GO_VERSION
+DEFAULT_GO_VERSION=1.21.3
+INSTALL_GO_VERSION=${GO_VERSION:-$DEFAULT_GO_VERSION}
+
 if [[ "${ARCH}" = "" ]]; then
   echo "environment value ARCH is not set"
   exit 1


### PR DESCRIPTION
CI環境でなぜか古いGoをインストールしてしまうので、明示的にインストールバージョンを指定できるようにしました（キャッシュなどの影響を受けづらくしました）