### PR TITLE
refactor: parallel scan

### DIFF
--- a/cloudsploit.yaml
+++ b/cloudsploit.yaml
@@ -6,6 +6,13 @@ ignorePlugin:
   - RDS/rdsSnapshotPubliclyAccessible
   - SNS/topicPolicies
   - SQS/sqsPublicAccess
+  - GuardDuty/guarddutyMaster
+  - GuardDuty/guarddutyEnabled
+  - ElastiCache/reservedNodePaymentPending
+  - ElastiCache/elasticCacheClusterHasTags
+  - EC2/securityGroupsHasTags
+  - EC2/multipleSubnets
+  - CodeStar/codestarValidRepoProviders
 specificPluginSetting:
   ACM/acmCertificateExpiry:
     score: 6

--- a/cmd/cloudsploit/main.go
+++ b/cmd/cloudsploit/main.go
@@ -65,6 +65,9 @@ func main() {
 	if err != nil {
 		appLogger.Fatal(ctx, err.Error())
 	}
+	if conf.Debug == "true" {
+		appLogger.Level(logging.DebugLevel)
+	}
 
 	pTypes, err := profiler.ConvertProfileTypeFrom(conf.ProfileTypes)
 	if err != nil {

--- a/pkg/cloudsploit/cloudsploit_test.go
+++ b/pkg/cloudsploit/cloudsploit_test.go
@@ -43,15 +43,6 @@ func TestRemoveIgnorePlugin(t *testing.T) {
 			},
 		},
 		{
-			name: "Ignore plugin",
-			input: args{
-				findings: []*cloudSploitResult{
-					{Category: "category", Plugin: "ignorePlugin", Resource: "resourceName"},
-				},
-			},
-			want: []*cloudSploitResult{},
-		},
-		{
 			name: "Ignore resource name pattern",
 			input: args{
 				findings: []*cloudSploitResult{

--- a/pkg/cloudsploit/handler.go
+++ b/pkg/cloudsploit/handler.go
@@ -78,16 +78,10 @@ func (s *SqsHandler) HandleMessage(ctx context.Context, sqsMsg *types.Message) e
 		return mimosasqs.WrapNonRetryable(err)
 	}
 
-	err = s.cloudsploitConf.generate(ctx, msg.AssumeRoleArn, msg.ExternalID, msg.AWSID, msg.AccountID)
-	if err != nil {
-		s.updateStatusToError(ctx, &status, err)
-		return mimosasqs.WrapNonRetryable(err)
-	}
-
 	// Run cloudsploit
 	tspan, _ := tracer.StartSpanFromContext(ctx, "runCloudSploit")
 	s.logger.Infof(ctx, "start cloudsploit scan, RequestID=%s", requestID)
-	cloudsploitResult, err := s.run(ctx, msg.AccountID)
+	cloudsploitResult, err := s.run(ctx, msg)
 	tspan.Finish(tracer.WithError(err))
 	if err != nil {
 		s.logger.Errorf(ctx, "Failed to exec cloudsploit, error: %v", err)


### PR DESCRIPTION
pluginごとのスキャンに処理を分割し、パラレルで実行するようにリファクタします。
主に以下のメリットがあります

- エラーになってしまうプラグインを除外できるようになる
- パフォーマンスが向上する（cloudsploitは10並列での処理なので、これ以上に設定することでスキャン速度が上がる）

また、今の固定バージョンだと以下のプラグインはエラーになるか、時間がかかりすぎる（数時間レベル）ことが分かったので除外します。
- GuardDuty/guarddutyMaster
- GuardDuty/guarddutyEnabled
- ElastiCache/reservedNodePaymentPending
- ElastiCache/elasticCacheClusterHasTags
- EC2/securityGroupsHasTags
- EC2/multipleSubnets
- CodeStar/codestarValidRepoProviders
