### PR TITLE
fix: timeout

### DIFF
--- a/pkg/cloudsploit/cloudsploit.go
+++ b/pkg/cloudsploit/cloudsploit.go
@@ -52,7 +52,7 @@ func NewCloudsploitConfig(
 }
 
 const (
-	SCAN_TIMEOUT = 1 * time.Hour
+	SCAN_TIMEOUT = 30 * time.Minute
 )
 
 func (s *SqsHandler) run(ctx context.Context, msg *message.AWSQueueMessage) ([]*cloudSploitResult, error) {


### PR DESCRIPTION
タイムアウト1hではその前にコンテナが死んでしまう事象を確認しました。
つまり、タイムアウトがうまく効いてない印象なので少し短くします