### PR TITLE
add: lambda action

### DIFF
--- a/pkg/accessanalyzer/handler_test.go
+++ b/pkg/accessanalyzer/handler_test.go
@@ -60,6 +60,15 @@ func TestScoreAccessAnalyzerFinding(t *testing.T) {
 			},
 			want: 1.0,
 		},
+		{
+			name:     "Public (lambda function url)",
+			status:   types.FindingStatusActive,
+			isPublic: true,
+			actions: []string{
+				"lambda:InvokeFunctionUrl",
+			},
+			want: 0.7,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {


### PR DESCRIPTION
Lambdaがパブリックの場合でも、lambda:InvokeFunctionUrlのアクションのみの場合はスコアを下げます。
その他、不使用変数の削除などのリファクタリングしてます