### PR TITLE
Feat/dspm

### DIFF
--- a/pkg/accessanalyzer/dlp.go
+++ b/pkg/accessanalyzer/dlp.go
@@ -109,10 +109,10 @@ func (a *accessAnalyzerClient) dlpScan(ctx context.Context, bucketArn string, fi
 	a.logger.Infof(ctx, "Starting staged DLP scan for public S3 bucket: %s", bucketName)
 
 	// Check previous DLP scan results to avoid duplicate scanning
-	previousResult, err := a.getPreviousDLPFindings(ctx, bucketName, projectID)
+	prevScanResult, err := a.getPreviousDLPFindings(ctx, bucketName, projectID)
 	if err != nil {
 		a.logger.Warnf(ctx, "Failed to get previous DLP findings: %v", err)
-		previousResult = nil
+		prevScanResult = nil
 	}
 
 	// Collect metadata for s3 objects (lightweight)
@@ -124,10 +124,10 @@ func (a *accessAnalyzerClient) dlpScan(ctx context.Context, bucketArn string, fi
 	var filteredCandidates []FileCandidate
 	var cachedFindings []DLPFinding
 	var scanResults *DLPScanResult
-	if previousResult != nil {
+	if prevScanResult != nil && prevScanResult.ScanTime > 0 {
 		// Filter candidates based on previous scan results and object modification time
-		filteredCandidates, cachedFindings = a.filterCandidatesWithCache(ctx, candidates, previousResult, bucketName)
-		scanResults = previousResult // preset scan results(maybe new scan later)
+		filteredCandidates, cachedFindings = a.filterCandidatesWithCache(ctx, candidates, prevScanResult, bucketName)
+		scanResults = prevScanResult // preset scan results(maybe new scan later)
 	} else {
 		filteredCandidates = candidates
 	}

--- a/pkg/accessanalyzer/dlp.go
+++ b/pkg/accessanalyzer/dlp.go
@@ -435,7 +435,9 @@ func (a *accessAnalyzerClient) processScanResults(ctx context.Context, outputFil
 		// Limit matches to maximum MAX_MATCHES_PER_FINDING items
 		matches := finding.Matches
 		if len(matches) > MAX_MATCHES_PER_FINDING {
+			remainingCount := len(matches) - MAX_MATCHES_PER_FINDING
 			matches = matches[:MAX_MATCHES_PER_FINDING]
+			matches = append(matches, fmt.Sprintf("... and %d more", remainingCount))
 		}
 
 		findings = append(findings, DLPFinding{

--- a/pkg/accessanalyzer/dlp.go
+++ b/pkg/accessanalyzer/dlp.go
@@ -21,6 +21,7 @@ const (
 	MAX_SCAN_SIZE_BYTES        = MAX_SCAN_SIZE_MB * 1024 * 1024
 	MAX_SINGLE_FILE_SIZE_MB    = 5
 	MAX_SINGLE_FILE_SIZE_BYTES = MAX_SINGLE_FILE_SIZE_MB * 1024 * 1024
+	MAX_MATCHES_PER_FINDING    = 5
 )
 
 // FileCandidate represents a file candidate for scanning
@@ -362,10 +363,17 @@ func (a *accessAnalyzerClient) processScanResults(ctx context.Context, outputFil
 	findings := []DLPFinding{}
 	for _, finding := range hawkEyeOutput.Fs {
 		path := strings.ReplaceAll(finding.FilePath, tempDir, "")
+
+		// Limit matches to maximum MAX_MATCHES_PER_FINDING items
+		matches := finding.Matches
+		if len(matches) > MAX_MATCHES_PER_FINDING {
+			matches = matches[:MAX_MATCHES_PER_FINDING]
+		}
+
 		findings = append(findings, DLPFinding{
 			FilePath:            filepath.Join("s3://", bucketName, path),
 			PatternName:         finding.PatternName,
-			Matches:             finding.Matches,
+			Matches:             matches,
 			Severity:            finding.Severity,
 			SeverityDescription: finding.SeverityDescription,
 		})

--- a/pkg/accessanalyzer/finding.go
+++ b/pkg/accessanalyzer/finding.go
@@ -1,0 +1,142 @@
+package accessanalyzer
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/ca-risken/core/proto/finding"
+	"github.com/ca-risken/datasource-api/pkg/message"
+)
+
+
+// getPreviousDLPFindings retrieves previous DLP scan results for the specified bucket
+func (a *accessAnalyzerClient) getPreviousDLPFindings(ctx context.Context, bucketName string, projectID uint32) (*DLPScanResult, error) {
+	bucketArn := fmt.Sprintf("arn:aws:s3:::%s", bucketName)
+	a.logger.Debugf(ctx, "Retrieving previous DLP findings for bucket: %s", bucketArn)
+
+	// Search for existing DLP findings using ListFinding API
+	listReq := &finding.ListFindingRequest{
+		ProjectId:    projectID,
+		DataSource:   []string{message.AWSAccessAnalyzerDataSource},
+		ResourceName: []string{bucketArn},
+		Limit:        1, // Only get the first finding
+	}
+	resp, err := a.FindingClient.ListFinding(ctx, listReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list previous DLP findings: %w", err)
+	}
+	if len(resp.FindingId) == 0 {
+		a.logger.Debugf(ctx, "No previous DLP findings found for bucket: %s", bucketName)
+		return nil, nil
+	}
+
+	// Process only the first finding
+	findingID := resp.FindingId[0]
+	getReq := &finding.GetFindingRequest{
+		ProjectId: projectID,
+		FindingId: findingID,
+	}
+
+	findingResp, err := a.FindingClient.GetFinding(ctx, getReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get finding details for ID %d: %w", findingID, err)
+	}
+
+	// Check if this finding contains DLP scan results
+	if !a.isDLPFinding(findingResp.Finding) {
+		a.logger.Debugf(ctx, "Finding ID %d is not a DLP finding", findingID)
+		return nil, nil
+	}
+	scanResult, err := a.parseDLPFindingData(findingResp.Finding.Data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse DLP finding data for ID %d: %w", findingID, err)
+	}
+
+	// ScanTime is now used for previous scan time comparison
+	a.logger.Debugf(ctx, "Loaded previous DLP scan result: bucket=%s, lastScan=%v, files=%d",
+		bucketName, time.Unix(scanResult.ScanTime, 0), len(scanResult.Findings))
+
+	return scanResult, nil
+}
+
+// isDLPFinding checks if a finding contains DLP scan results by checking for dlp_scan key
+func (a *accessAnalyzerClient) isDLPFinding(f *finding.Finding) bool {
+	var parsedData map[string]any
+	if err := json.Unmarshal([]byte(f.Data), &parsedData); err != nil {
+		return false
+	}
+
+	// Check for dlp_scan key existence
+	_, hasDLPScan := parsedData["dlp_scan"]
+	return hasDLPScan
+}
+
+// parseDLPFindingData parses DLP scan result data from Finding.Data
+func (a *accessAnalyzerClient) parseDLPFindingData(data string) (*DLPScanResult, error) {
+	var parsedData map[string]any
+	if err := json.Unmarshal([]byte(data), &parsedData); err != nil {
+		return nil, fmt.Errorf("failed to parse finding data as JSON: %w", err)
+	}
+
+	// Extract dlp_scan data
+	dlpScanData, ok := parsedData["dlp_scan"]
+	if !ok {
+		return nil, fmt.Errorf("no dlp_scan data found in finding")
+	}
+
+	// Convert to JSON bytes and parse as DLPScanResult
+	dlpBytes, err := json.Marshal(dlpScanData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal dlp_scan data: %w", err)
+	}
+
+	var dlpResult DLPScanResult
+	if err := json.Unmarshal(dlpBytes, &dlpResult); err != nil {
+		return nil, fmt.Errorf("failed to parse DLP scan result: %w", err)
+	}
+
+	return &dlpResult, nil
+}
+
+// filterCandidatesWithCache filters file candidates based on previous scan results and object modification time
+func (a *accessAnalyzerClient) filterCandidatesWithCache(ctx context.Context, candidates []FileCandidate, previousResult *DLPScanResult, bucketName string) ([]FileCandidate, []DLPFinding) {
+	if previousResult == nil {
+		a.logger.Debugf(ctx, "No previous findings available, scanning all %d candidates", len(candidates))
+		return candidates, nil
+	}
+
+	var toScan []FileCandidate
+	var cachedFindings []DLPFinding
+	skippedCount := 0
+
+	a.logger.Debugf(ctx, "Filtering candidates based on previous scan time: %v", time.Unix(previousResult.ScanTime, 0))
+
+	// Create map from findings for easier lookup
+	fileResults := make(map[string]DLPFinding)
+	for _, finding := range previousResult.Findings {
+		fileResults[finding.FilePath] = finding
+	}
+
+	for _, candidate := range candidates {
+		filePath := fmt.Sprintf("%s/%s", bucketName, candidate.Key)
+
+		// Skip files that haven't been modified since last scan
+		if candidate.LastModified != nil && candidate.LastModified.Unix() < previousResult.ScanTime {
+			if previousFinding, found := fileResults[filePath]; found {
+				cachedFindings = append(cachedFindings, previousFinding)
+				a.logger.Debugf(ctx, "Reusing cached finding for file %s: last modified %v < last scan %v",
+					candidate.Key, candidate.LastModified, time.Unix(previousResult.ScanTime, 0))
+			}
+			skippedCount++
+			continue
+		}
+		toScan = append(toScan, candidate) // File is new or has been modified since last scan
+	}
+
+	a.logger.Infof(ctx, "DLP scan optimization: %d files to scan, %d files skipped (cached), %d cached findings reused",
+		len(toScan), skippedCount, len(cachedFindings))
+
+	return toScan, cachedFindings
+}

--- a/pkg/accessanalyzer/handler.go
+++ b/pkg/accessanalyzer/handler.go
@@ -76,7 +76,7 @@ func (s *SqsHandler) HandleMessage(ctx context.Context, sqsMsg *sqsTypes.Message
 		s.updateStatusToError(ctx, &status, err)
 		return mimosasqs.WrapNonRetryable(err)
 	}
-	accessAnalyzer, err := newAccessAnalyzerClient(ctx, s.awsRegion, msg, ds.DataSource, s.retryMaxAttempts, s.dlpFingerprintPath, s.logger)
+	accessAnalyzer, err := newAccessAnalyzerClient(ctx, s.awsRegion, msg, ds.DataSource, s.retryMaxAttempts, s.dlpFingerprintPath, s.findingClient, s.logger)
 	if err != nil {
 		s.logger.Errorf(ctx, "Failed to create AccessAnalyzer session: err=%+v", err)
 		s.updateStatusToError(ctx, &status, err)
@@ -101,7 +101,7 @@ func (s *SqsHandler) HandleMessage(ctx context.Context, sqsMsg *sqsTypes.Message
 		}
 		s.logger.Infof(ctx, "Start %s region search...", *region.RegionName)
 		// AccessAnalyzer
-		accessAnalyzer, err = newAccessAnalyzerClient(ctx, *region.RegionName, msg, ds.DataSource, s.retryMaxAttempts, s.dlpFingerprintPath, s.logger)
+		accessAnalyzer, err = newAccessAnalyzerClient(ctx, *region.RegionName, msg, ds.DataSource, s.retryMaxAttempts, s.dlpFingerprintPath, s.findingClient, s.logger)
 		if err != nil {
 			s.logger.Errorf(ctx, "Failed to create AccessAnalyzer session: Region=%s, AccountID=%s, err=%+v", *region.RegionName, msg.AccountID, err)
 			s.updateStatusToError(ctx, &status, err)


### PR DESCRIPTION
DLPスキャンのパフォーマンスがかなり悪いため、以下の対策を実施します。

- スキャン対象のサンプリング数を3000 -> 1000に減らす
- WEBサイトホスティング向けのファイルを除外対象にする
- 一度スキャンしたファイルを毎回DL→スキャンしないように、前回結果（Finding）から取得して、更新がなければスキップする処理を入れます
- RISKEN DBのデータが肥大化する可能性があるため、マッチしたデータを最大5件まで保持するように修正（全件は保持しない）
