### PR TITLE
Disable IAM/trustedCrossAccountRoles cloudsploit plugin restoration

### DIFF
--- a/cloudsploit.yaml
+++ b/cloudsploit.yaml
@@ -13,7 +13,6 @@ ignorePlugin:
   - EC2/securityGroupsHasTags
   - EC2/multipleSubnets
   - CodeStar/codestarValidRepoProviders
-  - IAM/trustedCrossAccountRoles
 specificPluginSetting:
   ACM/acmCertificateExpiry:
     score: 6


### PR DESCRIPTION
## PRの概要

過去に IAM/trustedCrossAccountRoles プラグインがエラーを発生させたため、PR #338 で `cloudsploit.yaml` の `ignorePlugin` に追加してスキャン対象から外していました。その後 PR #339 で cloudsploit スキャンの実装をプラグイン単位のエラーを許容する（warn ログ出力のみで全体スキャンは継続する）形に変更したため、当該プラグインを ignore しておく必要がなくなりました。本PRでは `IAM/trustedCrossAccountRoles` を `ignorePlugin` から除外し、通常のスキャン対象として復帰させます。

## 動作確認例

- [ ] cloudsploit スキャンをローカルで実行し、IAM/trustedCrossAccountRoles の検出結果が Finding として RISKEN に登録されることを確認する
- [ ] 当該プラグインがエラーを発生させたケースでも、warn ログのみが出力されスキャン全体が継続する（他プラグインの結果が正常に登録される）ことを確認する

## レビュー観点例

- [ ] IAM/trustedCrossAccountRoles の復帰が PR #339 で導入されたプラグイン単位のエラー握りつぶし機構に依存している前提が妥当かどうか
- [ ] 当該プラグインの結果が Finding として登録されるようになることで、誤検知や運用上の混乱（重大度スコアやアラート発火頻度）への影響が許容できるかどうか
